### PR TITLE
use FlySystem for most filesystem operations

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -31,6 +31,7 @@ use AspirePress\AspireSync\Factories\Plugins\PluginListServiceFactory;
 use AspirePress\AspireSync\Factories\Plugins\PluginMetadataServiceFactory;
 use AspirePress\AspireSync\Factories\RevisionMetadataServiceFactory;
 use AspirePress\AspireSync\Factories\StatsMetadataServiceFactory;
+use AspirePress\AspireSync\Factories\SvnServiceFactory;
 use AspirePress\AspireSync\Factories\Themes\DownloadThemesCommandFactory;
 use AspirePress\AspireSync\Factories\Themes\DownloadThemesPartialCommandFactory;
 use AspirePress\AspireSync\Factories\Themes\InternalThemeDownloadCommandFactory;
@@ -85,6 +86,7 @@ class ConfigProvider
                 ThemesMetadataService::class   => ThemeMetadataServiceFactory::class,
                 PluginMetadataService::class   => PluginMetadataServiceFactory::class,
                 StatsMetadataService::class    => StatsMetadataServiceFactory::class,
+                SvnService::class              => SvnServiceFactory::class,
 
                 // Services
                 PluginDownloadFromWpService::class => PluginDownloadFromWpServiceFactory::class,

--- a/src/Factories/Plugins/PluginListServiceFactory.php
+++ b/src/Factories/Plugins/PluginListServiceFactory.php
@@ -10,6 +10,7 @@ use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Services\SvnService;
 use AspirePress\AspireSync\Services\WPEndpointClient;
 use Laminas\ServiceManager\ServiceManager;
+use League\Flysystem\Filesystem;
 
 class PluginListServiceFactory
 {
@@ -19,6 +20,7 @@ class PluginListServiceFactory
         $revisionService = $serviceManager->get(RevisionMetadataService::class);
         $svnService      = $serviceManager->get(SvnService::class);
         $wpClient        = $serviceManager->get(WPEndpointClient::class);
-        return new PluginListService($svnService, $pluginService, $revisionService, $wpClient);
+        $filesystem      = $serviceManager->get(Filesystem::class);
+        return new PluginListService($svnService, $pluginService, $revisionService, $wpClient, $filesystem);
     }
 }

--- a/src/Factories/SvnServiceFactory.php
+++ b/src/Factories/SvnServiceFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AspirePress\AspireSync\Factories;
+
+use AspirePress\AspireSync\Services\StatsMetadataService;
+use AspirePress\AspireSync\Services\SvnService;
+use Aura\Sql\ExtendedPdoInterface;
+use Laminas\ServiceManager\ServiceManager;
+use League\Flysystem\Filesystem;
+
+class SvnServiceFactory
+{
+    public function __invoke(ServiceManager $serviceManager): SvnService
+    {
+        $filesystem = $serviceManager->get(Filesystem::class);
+        return new SvnService($filesystem);
+    }
+}

--- a/src/Factories/Themes/ThemeListServiceFactory.php
+++ b/src/Factories/Themes/ThemeListServiceFactory.php
@@ -8,6 +8,7 @@ use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Services\Themes\ThemeListService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
 use Laminas\ServiceManager\ServiceManager;
+use League\Flysystem\Filesystem;
 
 class ThemeListServiceFactory
 {
@@ -15,6 +16,7 @@ class ThemeListServiceFactory
     {
         $themeMetadata    = $serviceManager->get(ThemesMetadataService::class);
         $revisionMetadata = $serviceManager->get(RevisionMetadataService::class);
-        return new ThemeListService($themeMetadata, $revisionMetadata);
+        $filesystem       = $serviceManager->get(Filesystem::class);
+        return new ThemeListService($themeMetadata, $revisionMetadata, $filesystem);
     }
 }


### PR DESCRIPTION
# Pull Request

## What changed?

* Everything that writes files now goes through flysystem (which creates directories on the fly, so those checks could be removed).  File writes are "atomic" in that a temp file is written to then renamed to the real file so that partial writes do not occur.

I haven't replaced every single filesystem operation with flysystem yet, and we'll probably want to abstract it some by that point, so that S3 doesn't write to tempfiles for instance (I think it's already more or less atomic).  

## Why did it change?

Atomic file writes make things more reliable.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.