### PR TITLE
add retry logic to Guzzle

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -21,6 +21,7 @@ use AspirePress\AspireSync\Factories\ExtendedPdoFactory;
 use AspirePress\AspireSync\Factories\Flysystem\AwsS3V3AdapterFactory;
 use AspirePress\AspireSync\Factories\Flysystem\FilesystemFactory;
 use AspirePress\AspireSync\Factories\Flysystem\LocalFilesystemAdapterFactory;
+use AspirePress\AspireSync\Factories\GuzzleClientFactory;
 use AspirePress\AspireSync\Factories\Plugins\DownloadPluginsCommandFactory;
 use AspirePress\AspireSync\Factories\Plugins\DownloadPluginsPartialCommandFactory;
 use AspirePress\AspireSync\Factories\Plugins\InternalPluginDownloadCommandFactory;
@@ -41,6 +42,7 @@ use AspirePress\AspireSync\Factories\Themes\ThemeDownloadFromWpServiceFactory;
 use AspirePress\AspireSync\Factories\Themes\ThemeListServiceFactory;
 use AspirePress\AspireSync\Factories\Themes\ThemeMetadataServiceFactory;
 use AspirePress\AspireSync\Factories\UtilUploadCommandFactory;
+use AspirePress\AspireSync\Factories\WpEndpointClientFactory;
 use AspirePress\AspireSync\Services\Plugins\PluginDownloadFromWpService;
 use AspirePress\AspireSync\Services\Plugins\PluginListService;
 use AspirePress\AspireSync\Services\Plugins\PluginMetadataService;
@@ -52,6 +54,7 @@ use AspirePress\AspireSync\Services\Themes\ThemeListService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
 use AspirePress\AspireSync\Services\WPEndpointClient;
 use Aura\Sql\ExtendedPdoInterface;
+use GuzzleHttp\Client as GuzzleClient;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
@@ -93,6 +96,8 @@ class ConfigProvider
                 ThemeListService::class            => ThemeListServiceFactory::class,
                 PluginListService::class           => PluginListServiceFactory::class,
                 ThemeDownloadFromWpService::class  => ThemeDownloadFromWpServiceFactory::class,
+                GuzzleClient::class                => GuzzleClientFactory::class,
+                WPEndpointClient::class            => WpEndpointClientFactory::class,
 
                 // Commands
                 DownloadPluginsCommand::class        => DownloadPluginsCommandFactory::class,

--- a/src/Factories/GuzzleClientFactory.php
+++ b/src/Factories/GuzzleClientFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AspirePress\AspireSync\Factories;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Laminas\ServiceManager\ServiceManager;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+
+class GuzzleClientFactory
+{
+    public function __invoke(ServiceManager $serviceManager): GuzzleClient
+    {
+        // https://codewithkyrian.com/p/how-to-implement-retries-in-guzzlehttp
+        $maxRetries = 5;
+        $handler = HandlerStack::create();
+        $retryMiddleware = Middleware::retry(
+            function (int $retries, RequestInterface $request, ?ResponseInterface $response, ?\RuntimeException $e)
+            use ($maxRetries) {
+                // Limit the number of retries to maxRetries
+                if ($retries >= $maxRetries) {
+                    return false;
+                }
+
+                // Retry connection exceptions
+                if ($e instanceof ConnectException) {
+                    // echo "Error connecting to " . $request->getUri() . ". Retrying (" . ($retries + 1) . "/" . $maxRetries . ")...\n";
+                    echo "ERROR [retrying]: {$request->getUri()}: {$e->getMessage()}\n";
+                    return true;
+                }
+
+                if ($response && in_array($response->getStatusCode(), [249, 429, 500, 502, 503, 504], true)) {
+                    // echo "Something went wrong on the server. Retrying (" . ($retries + 1) . "/" . $maxRetries . ")...\n";
+                    echo "ERROR [retrying]: {$request->getUri()}: {$response->getStatusCode()}\n";
+                    return true;
+                }
+
+                return false;
+            },
+            fn(int $retries) => 1000 * $retries,
+        );
+        $handler->push($retryMiddleware);
+
+        return new GuzzleClient(['handler' => $handler, 'timeout' => 5]);
+    }
+}
+

--- a/src/Factories/Plugins/PluginDownloadFromWpServiceFactory.php
+++ b/src/Factories/Plugins/PluginDownloadFromWpServiceFactory.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Factories\Plugins;
 
 use AspirePress\AspireSync\Services\Plugins\PluginDownloadFromWpService;
 use AspirePress\AspireSync\Services\Plugins\PluginMetadataService;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 
 class PluginDownloadFromWpServiceFactory
@@ -14,6 +15,7 @@ class PluginDownloadFromWpServiceFactory
     {
         $ua                = $serviceManager->get('config')['user-agents'];
         $pluginMetaService = $serviceManager->get(PluginMetadataService::class);
-        return new PluginDownloadFromWpService($ua, $pluginMetaService);
+        $guzzle            = $serviceManager->get(GuzzleClient::class);
+        return new PluginDownloadFromWpService($ua, $pluginMetaService, $guzzle);
     }
 }

--- a/src/Factories/SvnServiceFactory.php
+++ b/src/Factories/SvnServiceFactory.php
@@ -7,6 +7,7 @@ namespace AspirePress\AspireSync\Factories;
 use AspirePress\AspireSync\Services\StatsMetadataService;
 use AspirePress\AspireSync\Services\SvnService;
 use Aura\Sql\ExtendedPdoInterface;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 use League\Flysystem\Filesystem;
 
@@ -15,6 +16,7 @@ class SvnServiceFactory
     public function __invoke(ServiceManager $serviceManager): SvnService
     {
         $filesystem = $serviceManager->get(Filesystem::class);
-        return new SvnService($filesystem);
+        $guzzle = $serviceManager->get(GuzzleClient::class);
+        return new SvnService($filesystem, $guzzle);
     }
 }

--- a/src/Factories/Themes/ThemeDownloadFromWpServiceFactory.php
+++ b/src/Factories/Themes/ThemeDownloadFromWpServiceFactory.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Factories\Themes;
 
 use AspirePress\AspireSync\Services\Themes\ThemeDownloadFromWpService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 
 class ThemeDownloadFromWpServiceFactory
@@ -14,6 +15,8 @@ class ThemeDownloadFromWpServiceFactory
     {
         $ua            = $serviceManager->get('config')['user-agents'];
         $themeMetadata = $serviceManager->get(ThemesMetadataService::class);
-        return new ThemeDownloadFromWpService($ua, $themeMetadata);
+        $guzzle        = $serviceManager->get(GuzzleClient::class);
+
+        return new ThemeDownloadFromWpService($ua, $themeMetadata, $guzzle);
     }
 }

--- a/src/Factories/Themes/ThemeListServiceFactory.php
+++ b/src/Factories/Themes/ThemeListServiceFactory.php
@@ -7,6 +7,7 @@ namespace AspirePress\AspireSync\Factories\Themes;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Services\Themes\ThemeListService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 use League\Flysystem\Filesystem;
 
@@ -17,6 +18,8 @@ class ThemeListServiceFactory
         $themeMetadata    = $serviceManager->get(ThemesMetadataService::class);
         $revisionMetadata = $serviceManager->get(RevisionMetadataService::class);
         $filesystem       = $serviceManager->get(Filesystem::class);
-        return new ThemeListService($themeMetadata, $revisionMetadata, $filesystem);
+        $guzzle           = $serviceManager->get(GuzzleClient::class);
+
+        return new ThemeListService($themeMetadata, $revisionMetadata, $filesystem, $guzzle);
     }
 }

--- a/src/Factories/WpEndpointClientFactory.php
+++ b/src/Factories/WpEndpointClientFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AspirePress\AspireSync\Factories;
+
+use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
+use AspirePress\AspireSync\Services\WPEndpointClient;
+use GuzzleHttp\Client as GuzzleClient;
+use Laminas\ServiceManager\ServiceManager;
+
+class WpEndpointClientFactory
+{
+    public function __invoke(ServiceManager $serviceManager): WpEndpointClientInterface
+    {
+        $guzzle = $serviceManager->get(GuzzleClient::class);
+        return new WPEndpointClient($guzzle);
+    }
+}

--- a/src/Services/Plugins/PluginListService.php
+++ b/src/Services/Plugins/PluginListService.php
@@ -53,8 +53,10 @@ class PluginListService implements ListServiceInterface
 
         $filename = "/opt/aspiresync/data/plugin-raw-data/{$item}.json";
         $tmpname = $filename . ".tmp";
-        $this->filesystem->write($tmpname, $output);
-        $this->filesystem->move($tmpname, $filename);
+        // $this->filesystem->write($tmpname, $output);
+        // $this->filesystem->move($tmpname, $filename);
+        file_put_contents($tmpname, $output);
+        rename($tmpname, $filename);
 
         return json_decode($output, true);
     }

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -85,8 +85,10 @@ class SvnService implements SvnServiceInterface
             try {
                 $items    = $this->guzzle->get('https://' . $type . '.svn.wordpress.org/', ['headers' => ['AspireSync']]);
                 $contents = $items->getBody()->getContents();
-                $fs->write($tmpname, $contents);
-                $fs->move($tmpname, $filename);
+                // $fs->write($tmpname, $contents);
+                // $fs->move($tmpname, $filename);
+                file_put_contents($filename, $contents);
+                rename($tmpname, $filename);
                 $items = $contents;
             } catch (ClientException $e) {
                 throw new RuntimeException("Unable to download $type list: " . $e->getMessage());
@@ -105,8 +107,10 @@ class SvnService implements SvnServiceInterface
 
         $filename = "/opt/aspiresync/data/raw-$type-list";
         $tmpname = $filename . ".tmp";
-        $fs->write($tmpname, implode(PHP_EOL, $items));
-        $fs->move($tmpname, $filename);
+        // $fs->write($tmpname, implode(PHP_EOL, $items));
+        // $fs->move($tmpname, $filename);
+        file_put_contents($filename, implode(PHP_EOL, $items));
+        rename($tmpname, $filename);
 
         return ['items' => $itemsToReturn, 'revision' => $revision];
     }

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Services;
 
 use AspirePress\AspireSync\Services\Interfaces\SvnServiceInterface;
 use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
 use RuntimeException;
@@ -13,7 +14,10 @@ use Symfony\Component\Process\Process;
 
 class SvnService implements SvnServiceInterface
 {
-    public function __construct(private readonly Filesystem $filesystem) {}
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        private readonly GuzzleClient $guzzle,
+    ) {}
 
     public function getRevisionForType(string $type, int $prevRevision, int $lastRevision): array
     {
@@ -79,8 +83,7 @@ class SvnService implements SvnServiceInterface
             $contents = $items;
         } else {
             try {
-                $client   = new Client();
-                $items    = $client->get('https://' . $type . '.svn.wordpress.org/', ['headers' => ['AspireSync']]);
+                $items    = $this->guzzle->get('https://' . $type . '.svn.wordpress.org/', ['headers' => ['AspireSync']]);
                 $contents = $items->getBody()->getContents();
                 $fs->write($tmpname, $contents);
                 $fs->move($tmpname, $filename);

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -6,7 +6,7 @@ namespace AspirePress\AspireSync\Services\Themes;
 
 use AspirePress\AspireSync\Services\Interfaces\ListServiceInterface;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
-use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
 use RuntimeException;
@@ -20,6 +20,7 @@ class ThemeListService implements ListServiceInterface
         private ThemesMetadataService $themesMetadataService,
         private RevisionMetadataService $revisionService,
         private Filesystem $filesystem,
+        private GuzzleClient $guzzle,
     )
     {
     }
@@ -55,9 +56,8 @@ class ThemeListService implements ListServiceInterface
             'slug'     => $item,
             'fields[]' => 'versions',
         ];
-        $client      = new Client();
         try {
-            $response = $client->get($url, ['query' => $queryParams]);
+            $response = $this->guzzle->get($url, ['query' => $queryParams]);
             $data     = json_decode($response->getBody()->getContents(), true);
             $filename = "/opt/aspiresync/data/theme-raw-data/{$item}.json";
             $tmpname  = $filename . ".tmp";
@@ -151,8 +151,7 @@ class ThemeListService implements ListServiceInterface
             $contents = $themes;
         } else {
             try {
-                $client   = new Client();
-                $themes   = $client->get('https://themes.svn.wordpress.org/', ['headers' => ['User-Agent' => 'AspireSync']]);
+                $themes   = $this->guzzle->get('https://themes.svn.wordpress.org/', ['headers' => ['User-Agent' => 'AspireSync']]);
                 $contents = $themes->getBody()->getContents();
                 $tmpname  = $filename . ".tmp";
                 $fs->write($tmpname, $contents);

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -61,8 +61,10 @@ class ThemeListService implements ListServiceInterface
             $data     = json_decode($response->getBody()->getContents(), true);
             $filename = "/opt/aspiresync/data/theme-raw-data/{$item}.json";
             $tmpname  = $filename . ".tmp";
-            $this->filesystem->write($tmpname, json_encode($data, JSON_PRETTY_PRINT));
-            $this->filesystem->move($tmpname, $filename);
+            // $this->filesystem->write($tmpname, json_encode($data, JSON_PRETTY_PRINT));
+            // $this->filesystem->move($tmpname, $filename);
+            file_put_contents($tmpname, json_encode($data, JSON_PRETTY_PRINT));
+            rename($tmpname, $filename);
 
             return $data;
         } catch (ClientException $e) {
@@ -154,8 +156,10 @@ class ThemeListService implements ListServiceInterface
                 $themes   = $this->guzzle->get('https://themes.svn.wordpress.org/', ['headers' => ['User-Agent' => 'AspireSync']]);
                 $contents = $themes->getBody()->getContents();
                 $tmpname  = $filename . ".tmp";
-                $fs->write($tmpname, $contents);
-                $fs->move($tmpname, $filename);
+                // $fs->write($tmpname, $contents);
+                // $fs->move($tmpname, $filename);
+                file_put_contents($tmpname, $contents);
+                rename($tmpname, $filename);
                 $themes = $contents;
             } catch (ClientException $e) {
                 throw new RuntimeException('Unable to download theme list: ' . $e->getMessage());
@@ -174,8 +178,10 @@ class ThemeListService implements ListServiceInterface
 
         $filename = '/opt/aspiresync/data/raw-theme-list';
         $tmpname  = $filename . ".tmp";
-        $fs->write($tmpname, implode(PHP_EOL, $themes));
-        $fs->move($tmpname, $filename);
+        // $fs->write($tmpname, implode(PHP_EOL, $themes));
+        // $fs->move($tmpname, $filename);
+        file_put_contents($tmpname, implode(PHP_EOL, $themes));
+        rename($tmpname, $filename);
         $this->revisionService->setCurrentRevision($action, $revision);
         return $themesToReturn;
     }

--- a/src/Services/WPEndpointClient.php
+++ b/src/Services/WPEndpointClient.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace AspirePress\AspireSync\Services;
 
 use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
-use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 
 class WPEndpointClient implements WpEndpointClientInterface
 {
+    public function __construct(private readonly GuzzleClient $guzzle) {}
+
     public function getPluginMetadata(string $plugin): string
     {
         $url    = 'https://api.wordpress.org/plugins/info/1.0/' . $plugin . '.json';
-        $client = new Client();
         try {
-            $response = $client->get($url);
+            $response = $this->guzzle->get($url);
             return $response->getBody()->getContents();
         } catch (ClientException $e) {
             if ($e->getCode() === 404) {


### PR DESCRIPTION
# Pull Request

## What changed?

* Now injecting the Guzzle client as a service, configured with some retry logic.
* The $this->filesystem instance is not used when writing files, since flysystem apparently can't handle it without introducing race conditions that didn't exist before.

## Why did it change?

makes downloads more reliable.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.