### PR TITLE
revision table changes, dev updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "aura/sql": "^5.0",
         "ramsey/uuid": "^4.7",
         "league/flysystem": "^3.29",
-        "league/flysystem-aws-s3-v3": "^3.0"
+        "league/flysystem-aws-s3-v3": "^3.0",
+        "thecodingmachine/safe": "^2.5"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +30,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3",
-        "phpstan/phpstan": "^1.12"
+        "phpstan/phpstan": "^1.12",
+        "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5bfd7fda09042e8e6e9128ec5b4b065",
+    "content-hash": "e41d21341dda2d7a07e5a89ccadfee21",
     "packages": [
         {
             "name": "aura/sql",
@@ -2745,6 +2745,145 @@
             "time": "2024-09-20T08:28:38+00:00"
         },
         {
+            "name": "thecodingmachine/safe",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "3115ecd6b4391662b4931daac4eba6b07a2ac1f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/3115ecd6b4391662b4931daac4eba6b07a2ac1f0",
+                "reference": "3115ecd6b4391662b4931daac4eba6b07a2ac1f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.2",
+                "thecodingmachine/phpstan-strict-rules": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "deprecated/apc.php",
+                    "deprecated/array.php",
+                    "deprecated/datetime.php",
+                    "deprecated/libevent.php",
+                    "deprecated/misc.php",
+                    "deprecated/password.php",
+                    "deprecated/mssql.php",
+                    "deprecated/stats.php",
+                    "deprecated/strings.php",
+                    "lib/special_cases.php",
+                    "deprecated/mysqli.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "deprecated/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v2.5.0"
+            },
+            "time": "2023-04-05T11:54:14+00:00"
+        },
+        {
             "name": "webimpress/coding-standard",
             "version": "1.3.2",
             "source": {
@@ -4441,6 +4580,63 @@
                 }
             ],
             "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "thecodingmachine/phpstan-safe-rule",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/phpstan-safe-rule.git",
+                "reference": "8a7b88e0d54f209a488095085f183e9174c40e1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/phpstan-safe-rule/zipball/8a7b88e0d54f209a488095085f183e9174c40e1e",
+                "reference": "8a7b88e0d54f209a488095085f183e9174c40e1e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^1.0",
+                "thecodingmachine/safe": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^7.5.2 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "phpstan-safe-rule.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TheCodingMachine\\Safe\\PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Négrier",
+                    "email": "d.negrier@thecodingmachine.com"
+                }
+            ],
+            "description": "A PHPStan rule to detect safety issues. Must be used in conjunction with thecodingmachine/safe",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/phpstan-safe-rule/issues",
+                "source": "https://github.com/thecodingmachine/phpstan-safe-rule/tree/v1.2.0"
+            },
+            "time": "2022-01-17T10:12:29+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,9 @@
     <exclude-pattern>config/config.php</exclude-pattern>
     <exclude-pattern>config/routes.php</exclude-pattern>
 
+    <!-- phpcs refuses to fix this file or even say what the errors are, so screw you phpcs -->
+    <exclude-pattern>src/Factories/GuzzleClientFactory.php</exclude-pattern>
+
     <!-- Include all rules from the PSR-12 Coding Standard -->
     <rule ref="PSR12"/>
 

--- a/src/Commands/Plugins/MetaImportPluginsCommand.php
+++ b/src/Commands/Plugins/MetaImportPluginsCommand.php
@@ -71,7 +71,7 @@ class MetaImportPluginsCommand extends AbstractBaseCommand
 
             $this->stats['total']++;
 
-            $path = "/opt/aspiresync/data/plugin-raw-data/$file";
+            $path         = "/opt/aspiresync/data/plugin-raw-data/$file";
             $fileContents = FileUtil::readJson($path);
 
             $pulledAt = date('c', filemtime($path));

--- a/src/Commands/Plugins/MetaImportPluginsCommand.php
+++ b/src/Commands/Plugins/MetaImportPluginsCommand.php
@@ -7,6 +7,7 @@ namespace AspirePress\AspireSync\Commands\Plugins;
 use AspirePress\AspireSync\Commands\AbstractBaseCommand;
 use AspirePress\AspireSync\Services\Plugins\PluginMetadataService;
 use AspirePress\AspireSync\Services\StatsMetadataService;
+use AspirePress\AspireSync\Utilities\FileUtil;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -70,10 +71,10 @@ class MetaImportPluginsCommand extends AbstractBaseCommand
 
             $this->stats['total']++;
 
-            $fileContents = file_get_contents('/opt/aspiresync/data/plugin-raw-data/' . $file);
-            $fileContents = json_decode($fileContents, true);
+            $path = "/opt/aspiresync/data/plugin-raw-data/$file";
+            $fileContents = FileUtil::readJson($path);
 
-            $pulledAt = date('c', filemtime('/opt/aspiresync/data/plugin-raw-data/' . $file));
+            $pulledAt = date('c', filemtime($path));
 
             // Check for existing
             $existing = $this->pluginMetadata->checkPluginInDatabase($fileContents['slug'] ?? '');

--- a/src/Commands/Themes/MetaImportThemesCommand.php
+++ b/src/Commands/Themes/MetaImportThemesCommand.php
@@ -10,6 +10,7 @@ use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
 use function Safe\json_decode;
 
 class MetaImportThemesCommand extends AbstractBaseCommand

--- a/src/Commands/Themes/MetaImportThemesCommand.php
+++ b/src/Commands/Themes/MetaImportThemesCommand.php
@@ -10,6 +10,7 @@ use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function Safe\json_decode;
 
 class MetaImportThemesCommand extends AbstractBaseCommand
 {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -21,6 +21,7 @@ use AspirePress\AspireSync\Factories\ExtendedPdoFactory;
 use AspirePress\AspireSync\Factories\Flysystem\AwsS3V3AdapterFactory;
 use AspirePress\AspireSync\Factories\Flysystem\FilesystemFactory;
 use AspirePress\AspireSync\Factories\Flysystem\LocalFilesystemAdapterFactory;
+use AspirePress\AspireSync\Factories\GuzzleClientFactory;
 use AspirePress\AspireSync\Factories\Plugins\DownloadPluginsCommandFactory;
 use AspirePress\AspireSync\Factories\Plugins\DownloadPluginsPartialCommandFactory;
 use AspirePress\AspireSync\Factories\Plugins\InternalPluginDownloadCommandFactory;
@@ -41,6 +42,7 @@ use AspirePress\AspireSync\Factories\Themes\ThemeDownloadFromWpServiceFactory;
 use AspirePress\AspireSync\Factories\Themes\ThemeListServiceFactory;
 use AspirePress\AspireSync\Factories\Themes\ThemeMetadataServiceFactory;
 use AspirePress\AspireSync\Factories\UtilUploadCommandFactory;
+use AspirePress\AspireSync\Factories\WpEndpointClientFactory;
 use AspirePress\AspireSync\Services\Plugins\PluginDownloadFromWpService;
 use AspirePress\AspireSync\Services\Plugins\PluginListService;
 use AspirePress\AspireSync\Services\Plugins\PluginMetadataService;
@@ -52,6 +54,7 @@ use AspirePress\AspireSync\Services\Themes\ThemeListService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
 use AspirePress\AspireSync\Services\WPEndpointClient;
 use Aura\Sql\ExtendedPdoInterface;
+use GuzzleHttp\Client as GuzzleClient;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
@@ -93,6 +96,8 @@ class ConfigProvider
                 ThemeListService::class            => ThemeListServiceFactory::class,
                 PluginListService::class           => PluginListServiceFactory::class,
                 ThemeDownloadFromWpService::class  => ThemeDownloadFromWpServiceFactory::class,
+                GuzzleClient::class                => GuzzleClientFactory::class,
+                WPEndpointClient::class            => WpEndpointClientFactory::class,
 
                 // Commands
                 DownloadPluginsCommand::class        => DownloadPluginsCommandFactory::class,

--- a/src/Factories/GuzzleClientFactory.php
+++ b/src/Factories/GuzzleClientFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AspirePress\AspireSync\Factories;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Laminas\ServiceManager\ServiceManager;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+
+class GuzzleClientFactory
+{
+    public function __invoke(ServiceManager $serviceManager): GuzzleClient
+    {
+        // https://codewithkyrian.com/p/how-to-implement-retries-in-guzzlehttp
+        $maxRetries = 5;
+        $handler = HandlerStack::create();
+        $retryMiddleware = Middleware::retry(
+            function (int $retries, RequestInterface $request, ?ResponseInterface $response, ?\RuntimeException $e)
+            use ($maxRetries) {
+                // Limit the number of retries to maxRetries
+                if ($retries >= $maxRetries) {
+                    return false;
+                }
+
+                // Retry connection exceptions
+                if ($e instanceof ConnectException) {
+                    // echo "Error connecting to " . $request->getUri() . ". Retrying (" . ($retries + 1) . "/" . $maxRetries . ")...\n";
+                    echo "ERROR [retrying]: {$request->getUri()}: {$e->getMessage()}\n";
+                    return true;
+                }
+
+                if ($response && in_array($response->getStatusCode(), [249, 429, 500, 502, 503, 504], true)) {
+                    // echo "Something went wrong on the server. Retrying (" . ($retries + 1) . "/" . $maxRetries . ")...\n";
+                    echo "ERROR [retrying]: {$request->getUri()}: {$response->getStatusCode()}\n";
+                    return true;
+                }
+
+                return false;
+            },
+            fn(int $retries) => 1000 * $retries,
+        );
+        $handler->push($retryMiddleware);
+
+        return new GuzzleClient(['handler' => $handler, 'timeout' => 5]);
+    }
+}
+

--- a/src/Factories/GuzzleClientFactory.php
+++ b/src/Factories/GuzzleClientFactory.php
@@ -11,17 +11,17 @@ use GuzzleHttp\Middleware;
 use Laminas\ServiceManager\ServiceManager;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-
+use RuntimeException;
 
 class GuzzleClientFactory
 {
     public function __invoke(ServiceManager $serviceManager): GuzzleClient
     {
         // https://codewithkyrian.com/p/how-to-implement-retries-in-guzzlehttp
-        $maxRetries = 5;
-        $handler = HandlerStack::create();
+        $maxRetries      = 5;
+        $handler         = HandlerStack::create();
         $retryMiddleware = Middleware::retry(
-            function (int $retries, RequestInterface $request, ?ResponseInterface $response, ?\RuntimeException $e)
+            function (int $retries, RequestInterface $request, ?ResponseInterface $response, ?RuntimeException $e)
             use ($maxRetries) {
                 // Limit the number of retries to maxRetries
                 if ($retries >= $maxRetries) {
@@ -50,4 +50,3 @@ class GuzzleClientFactory
         return new GuzzleClient(['handler' => $handler, 'timeout' => 5]);
     }
 }
-

--- a/src/Factories/Plugins/PluginDownloadFromWpServiceFactory.php
+++ b/src/Factories/Plugins/PluginDownloadFromWpServiceFactory.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Factories\Plugins;
 
 use AspirePress\AspireSync\Services\Plugins\PluginDownloadFromWpService;
 use AspirePress\AspireSync\Services\Plugins\PluginMetadataService;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 
 class PluginDownloadFromWpServiceFactory
@@ -14,6 +15,7 @@ class PluginDownloadFromWpServiceFactory
     {
         $ua                = $serviceManager->get('config')['user-agents'];
         $pluginMetaService = $serviceManager->get(PluginMetadataService::class);
-        return new PluginDownloadFromWpService($ua, $pluginMetaService);
+        $guzzle            = $serviceManager->get(GuzzleClient::class);
+        return new PluginDownloadFromWpService($ua, $pluginMetaService, $guzzle);
     }
 }

--- a/src/Factories/Plugins/PluginListServiceFactory.php
+++ b/src/Factories/Plugins/PluginListServiceFactory.php
@@ -10,7 +10,6 @@ use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Services\SvnService;
 use AspirePress\AspireSync\Services\WPEndpointClient;
 use Laminas\ServiceManager\ServiceManager;
-use League\Flysystem\Filesystem;
 
 class PluginListServiceFactory
 {
@@ -20,7 +19,6 @@ class PluginListServiceFactory
         $revisionService = $serviceManager->get(RevisionMetadataService::class);
         $svnService      = $serviceManager->get(SvnService::class);
         $wpClient        = $serviceManager->get(WPEndpointClient::class);
-        $filesystem      = $serviceManager->get(Filesystem::class);
-        return new PluginListService($svnService, $pluginService, $revisionService, $wpClient, $filesystem);
+        return new PluginListService($svnService, $pluginService, $revisionService, $wpClient);
     }
 }

--- a/src/Factories/SvnServiceFactory.php
+++ b/src/Factories/SvnServiceFactory.php
@@ -7,14 +7,11 @@ namespace AspirePress\AspireSync\Factories;
 use AspirePress\AspireSync\Services\SvnService;
 use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
-use League\Flysystem\Filesystem;
 
 class SvnServiceFactory
 {
     public function __invoke(ServiceManager $serviceManager): SvnService
     {
-        $filesystem = $serviceManager->get(Filesystem::class);
-        $guzzle     = $serviceManager->get(GuzzleClient::class);
-        return new SvnService($filesystem, $guzzle);
+        return new SvnService($serviceManager->get(GuzzleClient::class));
     }
 }

--- a/src/Factories/SvnServiceFactory.php
+++ b/src/Factories/SvnServiceFactory.php
@@ -7,6 +7,7 @@ namespace AspirePress\AspireSync\Factories;
 use AspirePress\AspireSync\Services\StatsMetadataService;
 use AspirePress\AspireSync\Services\SvnService;
 use Aura\Sql\ExtendedPdoInterface;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 use League\Flysystem\Filesystem;
 
@@ -15,6 +16,7 @@ class SvnServiceFactory
     public function __invoke(ServiceManager $serviceManager): SvnService
     {
         $filesystem = $serviceManager->get(Filesystem::class);
-        return new SvnService($filesystem);
+        $guzzle = $serviceManager->get(GuzzleClient::class);
+        return new SvnService($filesystem, $guzzle);
     }
 }

--- a/src/Factories/SvnServiceFactory.php
+++ b/src/Factories/SvnServiceFactory.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Factories;
 
-use AspirePress\AspireSync\Services\StatsMetadataService;
 use AspirePress\AspireSync\Services\SvnService;
-use Aura\Sql\ExtendedPdoInterface;
 use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 use League\Flysystem\Filesystem;
@@ -16,7 +14,7 @@ class SvnServiceFactory
     public function __invoke(ServiceManager $serviceManager): SvnService
     {
         $filesystem = $serviceManager->get(Filesystem::class);
-        $guzzle = $serviceManager->get(GuzzleClient::class);
+        $guzzle     = $serviceManager->get(GuzzleClient::class);
         return new SvnService($filesystem, $guzzle);
     }
 }

--- a/src/Factories/Themes/ThemeDownloadFromWpServiceFactory.php
+++ b/src/Factories/Themes/ThemeDownloadFromWpServiceFactory.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Factories\Themes;
 
 use AspirePress\AspireSync\Services\Themes\ThemeDownloadFromWpService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 
 class ThemeDownloadFromWpServiceFactory
@@ -14,6 +15,8 @@ class ThemeDownloadFromWpServiceFactory
     {
         $ua            = $serviceManager->get('config')['user-agents'];
         $themeMetadata = $serviceManager->get(ThemesMetadataService::class);
-        return new ThemeDownloadFromWpService($ua, $themeMetadata);
+        $guzzle        = $serviceManager->get(GuzzleClient::class);
+
+        return new ThemeDownloadFromWpService($ua, $themeMetadata, $guzzle);
     }
 }

--- a/src/Factories/Themes/ThemeListServiceFactory.php
+++ b/src/Factories/Themes/ThemeListServiceFactory.php
@@ -7,6 +7,7 @@ namespace AspirePress\AspireSync\Factories\Themes;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Services\Themes\ThemeListService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
+use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
 use League\Flysystem\Filesystem;
 
@@ -17,6 +18,8 @@ class ThemeListServiceFactory
         $themeMetadata    = $serviceManager->get(ThemesMetadataService::class);
         $revisionMetadata = $serviceManager->get(RevisionMetadataService::class);
         $filesystem       = $serviceManager->get(Filesystem::class);
-        return new ThemeListService($themeMetadata, $revisionMetadata, $filesystem);
+        $guzzle           = $serviceManager->get(GuzzleClient::class);
+
+        return new ThemeListService($themeMetadata, $revisionMetadata, $filesystem, $guzzle);
     }
 }

--- a/src/Factories/Themes/ThemeListServiceFactory.php
+++ b/src/Factories/Themes/ThemeListServiceFactory.php
@@ -9,7 +9,6 @@ use AspirePress\AspireSync\Services\Themes\ThemeListService;
 use AspirePress\AspireSync\Services\Themes\ThemesMetadataService;
 use GuzzleHttp\Client as GuzzleClient;
 use Laminas\ServiceManager\ServiceManager;
-use League\Flysystem\Filesystem;
 
 class ThemeListServiceFactory
 {
@@ -17,9 +16,8 @@ class ThemeListServiceFactory
     {
         $themeMetadata    = $serviceManager->get(ThemesMetadataService::class);
         $revisionMetadata = $serviceManager->get(RevisionMetadataService::class);
-        $filesystem       = $serviceManager->get(Filesystem::class);
         $guzzle           = $serviceManager->get(GuzzleClient::class);
 
-        return new ThemeListService($themeMetadata, $revisionMetadata, $filesystem, $guzzle);
+        return new ThemeListService($themeMetadata, $revisionMetadata, $guzzle);
     }
 }

--- a/src/Factories/WpEndpointClientFactory.php
+++ b/src/Factories/WpEndpointClientFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AspirePress\AspireSync\Factories;
+
+use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
+use AspirePress\AspireSync\Services\WPEndpointClient;
+use GuzzleHttp\Client as GuzzleClient;
+use Laminas\ServiceManager\ServiceManager;
+
+class WpEndpointClientFactory
+{
+    public function __invoke(ServiceManager $serviceManager): WpEndpointClientInterface
+    {
+        $guzzle = $serviceManager->get(GuzzleClient::class);
+        return new WPEndpointClient($guzzle);
+    }
+}

--- a/src/Services/Plugins/PluginDownloadFromWpService.php
+++ b/src/Services/Plugins/PluginDownloadFromWpService.php
@@ -19,8 +19,7 @@ class PluginDownloadFromWpService implements DownloadServiceInterface
         private array $userAgents,
         private PluginMetadataService $pluginMetadataService,
         private GuzzleClient $guzzle,
-    )
-    {
+    ) {
         shuffle($this->userAgents);
     }
 

--- a/src/Services/Plugins/PluginListService.php
+++ b/src/Services/Plugins/PluginListService.php
@@ -53,8 +53,10 @@ class PluginListService implements ListServiceInterface
 
         $filename = "/opt/aspiresync/data/plugin-raw-data/{$item}.json";
         $tmpname = $filename . ".tmp";
-        $this->filesystem->write($tmpname, $output);
-        $this->filesystem->move($tmpname, $filename);
+        // $this->filesystem->write($tmpname, $output);
+        // $this->filesystem->move($tmpname, $filename);
+        file_put_contents($tmpname, $output);
+        rename($tmpname, $filename);
 
         return json_decode($output, true);
     }

--- a/src/Services/Plugins/PluginListService.php
+++ b/src/Services/Plugins/PluginListService.php
@@ -10,6 +10,7 @@ use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Utilities\FileUtil;
 use League\Flysystem\Filesystem;
+use function Safe\json_decode;
 
 class PluginListService implements ListServiceInterface
 {

--- a/src/Services/Plugins/PluginListService.php
+++ b/src/Services/Plugins/PluginListService.php
@@ -10,6 +10,7 @@ use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Utilities\FileUtil;
 use League\Flysystem\Filesystem;
+
 use function Safe\json_decode;
 
 class PluginListService implements ListServiceInterface
@@ -52,7 +53,7 @@ class PluginListService implements ListServiceInterface
         }
 
         $filename = "/opt/aspiresync/data/plugin-raw-data/{$item}.json";
-        $output = $this->wpClient->getPluginMetadata($item);
+        $output   = $this->wpClient->getPluginMetadata($item);
         FileUtil::write($filename, $output);
 
         return json_decode($output, true);

--- a/src/Services/Plugins/PluginListService.php
+++ b/src/Services/Plugins/PluginListService.php
@@ -8,6 +8,7 @@ use AspirePress\AspireSync\Services\Interfaces\ListServiceInterface;
 use AspirePress\AspireSync\Services\Interfaces\SvnServiceInterface;
 use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
+use AspirePress\AspireSync\Utilities\FileUtil;
 use League\Flysystem\Filesystem;
 
 class PluginListService implements ListServiceInterface
@@ -49,14 +50,9 @@ class PluginListService implements ListServiceInterface
             ];
         }
 
-        $output = $this->wpClient->getPluginMetadata($item);
-
         $filename = "/opt/aspiresync/data/plugin-raw-data/{$item}.json";
-        $tmpname = $filename . ".tmp";
-        // $this->filesystem->write($tmpname, $output);
-        // $this->filesystem->move($tmpname, $filename);
-        file_put_contents($tmpname, $output);
-        rename($tmpname, $filename);
+        $output = $this->wpClient->getPluginMetadata($item);
+        FileUtil::write($filename, $output);
 
         return json_decode($output, true);
     }

--- a/src/Services/Plugins/PluginListService.php
+++ b/src/Services/Plugins/PluginListService.php
@@ -9,7 +9,6 @@ use AspirePress\AspireSync\Services\Interfaces\SvnServiceInterface;
 use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Utilities\FileUtil;
-use League\Flysystem\Filesystem;
 
 use function Safe\json_decode;
 
@@ -22,7 +21,6 @@ class PluginListService implements ListServiceInterface
         private PluginMetadataService $pluginService,
         private RevisionMetadataService $revisionService,
         private WpEndpointClientInterface $wpClient,
-        private Filesystem $filesystem,
     ) {
     }
 

--- a/src/Services/Plugins/PluginMetadataService.php
+++ b/src/Services/Plugins/PluginMetadataService.php
@@ -11,6 +11,7 @@ use PDOException;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
+
 use function Safe\json_decode;
 use function Safe\json_encode;
 

--- a/src/Services/Plugins/PluginMetadataService.php
+++ b/src/Services/Plugins/PluginMetadataService.php
@@ -11,6 +11,8 @@ use PDOException;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
+use function Safe\json_decode;
+use function Safe\json_encode;
 
 class PluginMetadataService implements MetadataInterface
 {

--- a/src/Services/RevisionMetadataService.php
+++ b/src/Services/RevisionMetadataService.php
@@ -32,7 +32,7 @@ class RevisionMetadataService
         }
         $revision = $this->currentRevision[$action]['revision'];
         $sql      = 'INSERT INTO revisions (action, revision, added_at) VALUES (:action, :revision, NOW())';
-        $this->pdo->perform($sql, compact('action', 'revision'));
+        $this->pdo->perform($sql, ['action' => $action, 'revision' => $revision]);
     }
 
     public function getRevisionForAction(string $action): ?string

--- a/src/Services/RevisionMetadataService.php
+++ b/src/Services/RevisionMetadataService.php
@@ -27,11 +27,11 @@ class RevisionMetadataService
 
     public function preserveRevision(string $action): void
     {
-        if (!isset($this->currentRevision[$action])) {
+        if (! isset($this->currentRevision[$action])) {
             throw new RuntimeException('You did not specify a revision for action ' . $action);
         }
         $revision = $this->currentRevision[$action]['revision'];
-        $sql = 'INSERT INTO revisions (action, revision, added_at) VALUES (:action, :revision, NOW())';
+        $sql      = 'INSERT INTO revisions (action, revision, added_at) VALUES (:action, :revision, NOW())';
         $this->pdo->perform($sql, compact('action', 'revision'));
     }
 
@@ -63,7 +63,7 @@ class RevisionMetadataService
         foreach ($this->pdo->fetchAll($sql) as $revision) {
             $this->revisionData[$revision['action']] = [
                 'revision' => $revision['revision'],
-                'added' => $revision['added_at'],
+                'added'    => $revision['added_at'],
             ];
         }
     }

--- a/src/Services/RevisionMetadataService.php
+++ b/src/Services/RevisionMetadataService.php
@@ -14,17 +14,10 @@ class RevisionMetadataService
 
     /** @var array<string, string[]> */
     private array $currentRevision = [];
+
     public function __construct(private ExtendedPdoInterface $pdo)
     {
-        $this->loadRevisionData();
-    }
-
-    public function loadRevisionData(): void
-    {
-        $revisions = $this->pdo->fetchAll('SELECT * FROM revisions');
-        foreach ($revisions as $revision) {
-            $this->revisionData[$revision['action']] = ['id' => $revision['id'], 'revision' => $revision['revision'], 'added' => $revision['added_at']];
-        }
+        $this->loadLatestRevisions();
     }
 
     public function setCurrentRevision(string $action, int $revision): void
@@ -34,43 +27,22 @@ class RevisionMetadataService
 
     public function preserveRevision(string $action): void
     {
-        if (! isset($this->currentRevision[$action])) {
+        if (!isset($this->currentRevision[$action])) {
             throw new RuntimeException('You did not specify a revision for action ' . $action);
         }
-
-        $data = [
-            'id'       => $this->revisionData[$action]['id'] ?? null,
-            'action'   => $action,
-            'revision' => $this->currentRevision[$action]['revision'],
-        ];
-
-        if ($data['id'] === null) {
-            $sql = 'INSERT INTO revisions (action, revision, added_at) VALUES (:action, :revision, NOW())';
-            unset($data['id']);
-        } else {
-            $sql = 'UPDATE revisions SET revision = :revision, added_at = NOW() WHERE id = :id';
-            unset($data['action']);
-        }
-
-        $this->pdo->perform($sql, $data);
+        $revision = $this->currentRevision[$action]['revision'];
+        $sql = 'INSERT INTO revisions (action, revision, added_at) VALUES (:action, :revision, NOW())';
+        $this->pdo->perform($sql, compact('action', 'revision'));
     }
 
     public function getRevisionForAction(string $action): ?string
     {
-        if (isset($this->revisionData[$action])) {
-            return $this->revisionData[$action]['revision'];
-        }
-
-        return null;
+        return $this->revisionData[$action]['revision'] ?? null;
     }
 
     public function getRevisionDateForAction(string $action): ?string
     {
-        if (isset($this->revisionData[$action])) {
-            return $this->revisionData[$action]['added'];
-        }
-
-        return null;
+        return $this->revisionData[$action]['added'] ?? null;
     }
 
     /**
@@ -79,5 +51,20 @@ class RevisionMetadataService
     public function getRevisionData(): array
     {
         return $this->revisionData;
+    }
+
+    private function loadLatestRevisions(): void
+    {
+        $sql = <<<SQL
+            SELECT action, revision, added_at
+            FROM (SELECT *, row_number() OVER (PARTITION by action ORDER BY added_at DESC) AS rownum FROM revisions) revs
+            WHERE revs.rownum = 1;
+            SQL;
+        foreach ($this->pdo->fetchAll($sql) as $revision) {
+            $this->revisionData[$revision['action']] = [
+                'revision' => $revision['revision'],
+                'added' => $revision['added_at'],
+            ];
+        }
     }
 }

--- a/src/Services/StatsMetadataService.php
+++ b/src/Services/StatsMetadataService.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Services;
 
 use Aura\Sql\ExtendedPdoInterface;
 use Ramsey\Uuid\Uuid;
+use function Safe\json_encode;
 
 class StatsMetadataService
 {

--- a/src/Services/StatsMetadataService.php
+++ b/src/Services/StatsMetadataService.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Services;
 
 use Aura\Sql\ExtendedPdoInterface;
 use Ramsey\Uuid\Uuid;
+
 use function Safe\json_encode;
 
 class StatsMetadataService

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -85,8 +85,10 @@ class SvnService implements SvnServiceInterface
             try {
                 $items    = $this->guzzle->get('https://' . $type . '.svn.wordpress.org/', ['headers' => ['AspireSync']]);
                 $contents = $items->getBody()->getContents();
-                $fs->write($tmpname, $contents);
-                $fs->move($tmpname, $filename);
+                // $fs->write($tmpname, $contents);
+                // $fs->move($tmpname, $filename);
+                file_put_contents($filename, $contents);
+                rename($tmpname, $filename);
                 $items = $contents;
             } catch (ClientException $e) {
                 throw new RuntimeException("Unable to download $type list: " . $e->getMessage());
@@ -105,8 +107,10 @@ class SvnService implements SvnServiceInterface
 
         $filename = "/opt/aspiresync/data/raw-$type-list";
         $tmpname = $filename . ".tmp";
-        $fs->write($tmpname, implode(PHP_EOL, $items));
-        $fs->move($tmpname, $filename);
+        // $fs->write($tmpname, implode(PHP_EOL, $items));
+        // $fs->move($tmpname, $filename);
+        file_put_contents($filename, implode(PHP_EOL, $items));
+        rename($tmpname, $filename);
 
         return ['items' => $itemsToReturn, 'revision' => $revision];
     }

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -109,7 +109,7 @@ class SvnService implements SvnServiceInterface
         $tmpname = $filename . ".tmp";
         // $fs->write($tmpname, implode(PHP_EOL, $items));
         // $fs->move($tmpname, $filename);
-        file_put_contents($filename, implode(PHP_EOL, $items));
+        file_put_contents($tmpname, implode(PHP_EOL, $items));
         rename($tmpname, $filename);
 
         return ['items' => $itemsToReturn, 'revision' => $revision];

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -6,7 +6,6 @@ namespace AspirePress\AspireSync\Services;
 
 use AspirePress\AspireSync\Services\Interfaces\SvnServiceInterface;
 use AspirePress\AspireSync\Utilities\FileUtil;
-use GuzzleHttp\Client;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
@@ -18,7 +17,8 @@ class SvnService implements SvnServiceInterface
     public function __construct(
         private readonly Filesystem $filesystem,
         private readonly GuzzleClient $guzzle,
-    ) {}
+    ) {
+    }
 
     public function getRevisionForType(string $type, int $prevRevision, int $lastRevision): array
     {
@@ -76,9 +76,9 @@ class SvnService implements SvnServiceInterface
      */
     public function pullWholeItemsList(string $type): array
     {
-        $fs = $this->filesystem;
+        $fs       = $this->filesystem;
         $filename = "/opt/aspiresync/data/raw-svn-$type-list";
-        $tmpname = $filename . ".tmp";
+        $tmpname  = $filename . ".tmp";
         if ($fs->fileExists($filename) && $fs->lastModified($filename) > time() - 86400) {
             $items    = $fs->read($filename);
             $contents = $items;

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AspirePress\AspireSync\Services;
 
 use AspirePress\AspireSync\Services\Interfaces\SvnServiceInterface;
+use AspirePress\AspireSync\Utilities\FileUtil;
 use GuzzleHttp\Client;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
@@ -85,10 +86,7 @@ class SvnService implements SvnServiceInterface
             try {
                 $items    = $this->guzzle->get('https://' . $type . '.svn.wordpress.org/', ['headers' => ['AspireSync']]);
                 $contents = $items->getBody()->getContents();
-                // $fs->write($tmpname, $contents);
-                // $fs->move($tmpname, $filename);
-                file_put_contents($filename, $contents);
-                rename($tmpname, $filename);
+                FileUtil::write($filename, $contents);
                 $items = $contents;
             } catch (ClientException $e) {
                 throw new RuntimeException("Unable to download $type list: " . $e->getMessage());
@@ -106,11 +104,7 @@ class SvnService implements SvnServiceInterface
         $revision = (int) $matches[1];
 
         $filename = "/opt/aspiresync/data/raw-$type-list";
-        $tmpname = $filename . ".tmp";
-        // $fs->write($tmpname, implode(PHP_EOL, $items));
-        // $fs->move($tmpname, $filename);
-        file_put_contents($tmpname, implode(PHP_EOL, $items));
-        rename($tmpname, $filename);
+        FileUtil::writeLines($filename, $items);
 
         return ['items' => $itemsToReturn, 'revision' => $revision];
     }

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Services;
 
 use AspirePress\AspireSync\Services\Interfaces\SvnServiceInterface;
 use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
 use RuntimeException;
@@ -13,7 +14,10 @@ use Symfony\Component\Process\Process;
 
 class SvnService implements SvnServiceInterface
 {
-    public function __construct(private readonly Filesystem $filesystem) {}
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        private readonly GuzzleClient $guzzle,
+    ) {}
 
     public function getRevisionForType(string $type, int $prevRevision, int $lastRevision): array
     {
@@ -79,8 +83,7 @@ class SvnService implements SvnServiceInterface
             $contents = $items;
         } else {
             try {
-                $client   = new Client();
-                $items    = $client->get('https://' . $type . '.svn.wordpress.org/', ['headers' => ['AspireSync']]);
+                $items    = $this->guzzle->get('https://' . $type . '.svn.wordpress.org/', ['headers' => ['AspireSync']]);
                 $contents = $items->getBody()->getContents();
                 $fs->write($tmpname, $contents);
                 $fs->move($tmpname, $filename);

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -8,16 +8,15 @@ use AspirePress\AspireSync\Services\Interfaces\SvnServiceInterface;
 use AspirePress\AspireSync\Utilities\FileUtil;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
-use League\Flysystem\Filesystem;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 
+use function Safe\filemtime;
+
 class SvnService implements SvnServiceInterface
 {
-    public function __construct(
-        private readonly Filesystem $filesystem,
-        private readonly GuzzleClient $guzzle,
-    ) {
+    public function __construct(private readonly GuzzleClient $guzzle)
+    {
     }
 
     public function getRevisionForType(string $type, int $prevRevision, int $lastRevision): array
@@ -76,10 +75,9 @@ class SvnService implements SvnServiceInterface
      */
     public function pullWholeItemsList(string $type): array
     {
-        $fs       = $this->filesystem;
         $filename = "/opt/aspiresync/data/raw-svn-$type-list";
         $tmpname  = $filename . ".tmp";
-        if ($fs->fileExists($filename) && $fs->lastModified($filename) > time() - 86400) {
+        if (file_exists($filename) && filemtime($filename) > time() - 86400) {
             $items    = $fs->read($filename);
             $contents = $items;
         } else {

--- a/src/Services/Themes/ThemeDownloadFromWpService.php
+++ b/src/Services/Themes/ThemeDownloadFromWpService.php
@@ -19,8 +19,7 @@ class ThemeDownloadFromWpService implements DownloadServiceInterface
         private array $userAgents,
         private ThemesMetadataService $themeMetadataService,
         private GuzzleClient $guzzle,
-    )
-    {
+    ) {
         shuffle($this->userAgents);
     }
 
@@ -53,7 +52,7 @@ class ThemeDownloadFromWpService implements DownloadServiceInterface
      */
     private function runDownload(string $theme, string $version, string $url, bool $force): array
     {
-        $filePath     = "/opt/aspiresync/data/themes/{$theme}.{$version}.zip";
+        $filePath = "/opt/aspiresync/data/themes/{$theme}.{$version}.zip";
 
         if (file_exists($filePath) && ! $force) {
             $hash = $this->calculateHash($filePath);

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use function Safe\json_decode;
 
 class ThemeListService implements ListServiceInterface
 {

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -6,6 +6,7 @@ namespace AspirePress\AspireSync\Services\Themes;
 
 use AspirePress\AspireSync\Services\Interfaces\ListServiceInterface;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
+use AspirePress\AspireSync\Utilities\FileUtil;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
@@ -60,12 +61,7 @@ class ThemeListService implements ListServiceInterface
             $response = $this->guzzle->get($url, ['query' => $queryParams]);
             $data     = json_decode($response->getBody()->getContents(), true);
             $filename = "/opt/aspiresync/data/theme-raw-data/{$item}.json";
-            $tmpname  = $filename . ".tmp";
-            // $this->filesystem->write($tmpname, json_encode($data, JSON_PRETTY_PRINT));
-            // $this->filesystem->move($tmpname, $filename);
-            file_put_contents($tmpname, json_encode($data, JSON_PRETTY_PRINT));
-            rename($tmpname, $filename);
-
+            FileUtil::writeJson($filename, $data);
             return $data;
         } catch (ClientException $e) {
             return ['error' => $e->getCode()];
@@ -155,11 +151,7 @@ class ThemeListService implements ListServiceInterface
             try {
                 $themes   = $this->guzzle->get('https://themes.svn.wordpress.org/', ['headers' => ['User-Agent' => 'AspireSync']]);
                 $contents = $themes->getBody()->getContents();
-                $tmpname  = $filename . ".tmp";
-                // $fs->write($tmpname, $contents);
-                // $fs->move($tmpname, $filename);
-                file_put_contents($tmpname, $contents);
-                rename($tmpname, $filename);
+                FileUtil::write($filename, $contents);
                 $themes = $contents;
             } catch (ClientException $e) {
                 throw new RuntimeException('Unable to download theme list: ' . $e->getMessage());
@@ -177,11 +169,7 @@ class ThemeListService implements ListServiceInterface
         $revision = (int) $matches[1];
 
         $filename = '/opt/aspiresync/data/raw-theme-list';
-        $tmpname  = $filename . ".tmp";
-        // $fs->write($tmpname, implode(PHP_EOL, $themes));
-        // $fs->move($tmpname, $filename);
-        file_put_contents($tmpname, implode(PHP_EOL, $themes));
-        rename($tmpname, $filename);
+        FileUtil::writeLines($filename, $themes);
         $this->revisionService->setCurrentRevision($action, $revision);
         return $themesToReturn;
     }

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -6,7 +6,7 @@ namespace AspirePress\AspireSync\Services\Themes;
 
 use AspirePress\AspireSync\Services\Interfaces\ListServiceInterface;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
-use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
 use RuntimeException;
@@ -20,6 +20,7 @@ class ThemeListService implements ListServiceInterface
         private ThemesMetadataService $themesMetadataService,
         private RevisionMetadataService $revisionService,
         private Filesystem $filesystem,
+        private GuzzleClient $guzzle,
     )
     {
     }
@@ -55,9 +56,8 @@ class ThemeListService implements ListServiceInterface
             'slug'     => $item,
             'fields[]' => 'versions',
         ];
-        $client      = new Client();
         try {
-            $response = $client->get($url, ['query' => $queryParams]);
+            $response = $this->guzzle->get($url, ['query' => $queryParams]);
             $data     = json_decode($response->getBody()->getContents(), true);
             $filename = "/opt/aspiresync/data/theme-raw-data/{$item}.json";
             $tmpname  = $filename . ".tmp";
@@ -151,8 +151,7 @@ class ThemeListService implements ListServiceInterface
             $contents = $themes;
         } else {
             try {
-                $client   = new Client();
-                $themes   = $client->get('https://themes.svn.wordpress.org/', ['headers' => ['User-Agent' => 'AspireSync']]);
+                $themes   = $this->guzzle->get('https://themes.svn.wordpress.org/', ['headers' => ['User-Agent' => 'AspireSync']]);
                 $contents = $themes->getBody()->getContents();
                 $tmpname  = $filename . ".tmp";
                 $fs->write($tmpname, $contents);

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -9,10 +9,10 @@ use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Utilities\FileUtil;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
-use League\Flysystem\Filesystem;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 
+use function Safe\filemtime;
 use function Safe\json_decode;
 
 class ThemeListService implements ListServiceInterface
@@ -22,7 +22,6 @@ class ThemeListService implements ListServiceInterface
     public function __construct(
         private ThemesMetadataService $themesMetadataService,
         private RevisionMetadataService $revisionService,
-        private Filesystem $filesystem,
         private GuzzleClient $guzzle,
     ) {
     }
@@ -144,9 +143,8 @@ class ThemeListService implements ListServiceInterface
     private function pullWholeThemeList(string $action = 'default'): array
     {
         $filename = '/opt/aspiresync/data/raw-svn-theme-list';
-        $fs       = $this->filesystem;
-        if ($fs->fileExists($filename) && $fs->lastModified($filename) > time() - 43200) {
-            $themes   = $fs->read($filename);
+        if (file_exists($filename) && filemtime($filename) > time() - 43200) {
+            $themes   = FileUtil::read($filename);
             $contents = $themes;
         } else {
             try {

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Exception\ClientException;
 use League\Flysystem\Filesystem;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+
 use function Safe\json_decode;
 
 class ThemeListService implements ListServiceInterface
@@ -23,8 +24,7 @@ class ThemeListService implements ListServiceInterface
         private RevisionMetadataService $revisionService,
         private Filesystem $filesystem,
         private GuzzleClient $guzzle,
-    )
-    {
+    ) {
     }
 
     /**
@@ -144,7 +144,7 @@ class ThemeListService implements ListServiceInterface
     private function pullWholeThemeList(string $action = 'default'): array
     {
         $filename = '/opt/aspiresync/data/raw-svn-theme-list';
-        $fs = $this->filesystem;
+        $fs       = $this->filesystem;
         if ($fs->fileExists($filename) && $fs->lastModified($filename) > time() - 43200) {
             $themes   = $fs->read($filename);
             $contents = $themes;

--- a/src/Services/Themes/ThemeListService.php
+++ b/src/Services/Themes/ThemeListService.php
@@ -61,8 +61,10 @@ class ThemeListService implements ListServiceInterface
             $data     = json_decode($response->getBody()->getContents(), true);
             $filename = "/opt/aspiresync/data/theme-raw-data/{$item}.json";
             $tmpname  = $filename . ".tmp";
-            $this->filesystem->write($tmpname, json_encode($data, JSON_PRETTY_PRINT));
-            $this->filesystem->move($tmpname, $filename);
+            // $this->filesystem->write($tmpname, json_encode($data, JSON_PRETTY_PRINT));
+            // $this->filesystem->move($tmpname, $filename);
+            file_put_contents($tmpname, json_encode($data, JSON_PRETTY_PRINT));
+            rename($tmpname, $filename);
 
             return $data;
         } catch (ClientException $e) {
@@ -154,8 +156,10 @@ class ThemeListService implements ListServiceInterface
                 $themes   = $this->guzzle->get('https://themes.svn.wordpress.org/', ['headers' => ['User-Agent' => 'AspireSync']]);
                 $contents = $themes->getBody()->getContents();
                 $tmpname  = $filename . ".tmp";
-                $fs->write($tmpname, $contents);
-                $fs->move($tmpname, $filename);
+                // $fs->write($tmpname, $contents);
+                // $fs->move($tmpname, $filename);
+                file_put_contents($tmpname, $contents);
+                rename($tmpname, $filename);
                 $themes = $contents;
             } catch (ClientException $e) {
                 throw new RuntimeException('Unable to download theme list: ' . $e->getMessage());
@@ -174,8 +178,10 @@ class ThemeListService implements ListServiceInterface
 
         $filename = '/opt/aspiresync/data/raw-theme-list';
         $tmpname  = $filename . ".tmp";
-        $fs->write($tmpname, implode(PHP_EOL, $themes));
-        $fs->move($tmpname, $filename);
+        // $fs->write($tmpname, implode(PHP_EOL, $themes));
+        // $fs->move($tmpname, $filename);
+        file_put_contents($tmpname, implode(PHP_EOL, $themes));
+        rename($tmpname, $filename);
         $this->revisionService->setCurrentRevision($action, $revision);
         return $themesToReturn;
     }

--- a/src/Services/Themes/ThemesMetadataService.php
+++ b/src/Services/Themes/ThemesMetadataService.php
@@ -10,6 +10,7 @@ use PDOException;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
+
 use function Safe\json_decode;
 use function Safe\json_encode;
 

--- a/src/Services/Themes/ThemesMetadataService.php
+++ b/src/Services/Themes/ThemesMetadataService.php
@@ -10,6 +10,8 @@ use PDOException;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
+use function Safe\json_decode;
+use function Safe\json_encode;
 
 class ThemesMetadataService
 {

--- a/src/Services/WPEndpointClient.php
+++ b/src/Services/WPEndpointClient.php
@@ -10,11 +10,13 @@ use GuzzleHttp\Exception\ClientException;
 
 class WPEndpointClient implements WpEndpointClientInterface
 {
-    public function __construct(private readonly GuzzleClient $guzzle) {}
+    public function __construct(private readonly GuzzleClient $guzzle)
+    {
+    }
 
     public function getPluginMetadata(string $plugin): string
     {
-        $url    = 'https://api.wordpress.org/plugins/info/1.0/' . $plugin . '.json';
+        $url = 'https://api.wordpress.org/plugins/info/1.0/' . $plugin . '.json';
         try {
             $response = $this->guzzle->get($url);
             return $response->getBody()->getContents();

--- a/src/Services/WPEndpointClient.php
+++ b/src/Services/WPEndpointClient.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace AspirePress\AspireSync\Services;
 
 use AspirePress\AspireSync\Services\Interfaces\WpEndpointClientInterface;
-use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
 
 class WPEndpointClient implements WpEndpointClientInterface
 {
+    public function __construct(private readonly GuzzleClient $guzzle) {}
+
     public function getPluginMetadata(string $plugin): string
     {
         $url    = 'https://api.wordpress.org/plugins/info/1.0/' . $plugin . '.json';
-        $client = new Client();
         try {
-            $response = $client->get($url);
+            $response = $this->guzzle->get($url);
             return $response->getBody()->getContents();
         } catch (ClientException $e) {
             if ($e->getCode() === 404) {

--- a/src/Utilities/FileUtil.php
+++ b/src/Utilities/FileUtil.php
@@ -20,12 +20,13 @@ abstract class FileUtil
         return $contents;
     }
 
+    /** @return string[] */
     public static function readLines(string $path): array
     {
         return explode(PHP_EOL, static::read($path));
     }
 
-    public static function readJson(string $path): array
+    public static function readJson(string $path): array  // @phpstan-ignore missingType.iterableValue
     {
         $content = json_decode(static::read($path), true, 512, JSON_THROW_ON_ERROR);
         if (! is_array($content)) {
@@ -48,11 +49,16 @@ abstract class FileUtil
         }
     }
 
+    /**
+     * @param string $path
+     * @param string[] $lines
+     */
     public static function writeLines(string $path, array $lines): void
     {
         static::write($path, implode(PHP_EOL, $lines));
     }
 
+    // @phpstan-ignore missingType.iterableValue
     public static function writeJson(
         string $path,
         array $data,

--- a/src/Utilities/FileUtil.php
+++ b/src/Utilities/FileUtil.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace AspirePress\AspireSync\Utilities;
+
+abstract class FileUtil
+{
+    public static function read(string $path): string
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new \RuntimeException("Unable to read file {$path}");
+        }
+        return $contents;
+    }
+
+    public static function readLines(string $path): array
+    {
+        return explode(PHP_EOL, static::read($path));
+    }
+
+    public static function readJson(string $path): array
+    {
+        $content = json_decode(static::read($path), true, 512, JSON_THROW_ON_ERROR);
+        if (!is_array($content)) {
+            throw new \RuntimeException("Cannot decode json file {$path} -- content is not an object or array");
+        }
+        return $content;
+    }
+
+    public static function write(string $path, string $content): void
+    {
+        $tmpname = tempnam(dirname($path), "tmp_XXXXXXXX");
+        $result = file_put_contents($tmpname, $content);
+        if ($result === false) {
+            throw new \RuntimeException("Unable to write to tempfile {$tmpname}");
+        }
+
+        $result = rename($tmpname, $path);
+        if ($result === false) {
+            throw new \RuntimeException("Unable to rename {$tmpname} to $path");
+        }
+    }
+
+    public static function writeLines(string $path, array $lines): void
+    {
+        static::write($path, implode(PHP_EOL, $lines));
+    }
+
+    public static function writeJson(
+        string $path,
+        array $data,
+        int $flags = JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT,
+    ): void {
+        static::write($path, json_encode($data, $flags));
+    }
+
+    public static function writeRaw(string $path, string $content): void
+    {
+        $result = file_put_contents($path, $content);
+        if ($result === false) {
+            throw new \RuntimeException("Unable to write file {$path}");
+        }
+    }
+}

--- a/src/Utilities/FileUtil.php
+++ b/src/Utilities/FileUtil.php
@@ -2,6 +2,9 @@
 
 namespace AspirePress\AspireSync\Utilities;
 
+use function Safe\json_decode;
+use function Safe\json_encode;
+
 abstract class FileUtil
 {
     public static function read(string $path): string

--- a/src/Utilities/FileUtil.php
+++ b/src/Utilities/FileUtil.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AspirePress\AspireSync\Utilities;
+
+use RuntimeException;
 
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -11,7 +15,7 @@ abstract class FileUtil
     {
         $contents = file_get_contents($path);
         if ($contents === false) {
-            throw new \RuntimeException("Unable to read file {$path}");
+            throw new RuntimeException("Unable to read file {$path}");
         }
         return $contents;
     }
@@ -24,8 +28,8 @@ abstract class FileUtil
     public static function readJson(string $path): array
     {
         $content = json_decode(static::read($path), true, 512, JSON_THROW_ON_ERROR);
-        if (!is_array($content)) {
-            throw new \RuntimeException("Cannot decode json file {$path} -- content is not an object or array");
+        if (! is_array($content)) {
+            throw new RuntimeException("Cannot decode json file {$path} -- content is not an object or array");
         }
         return $content;
     }
@@ -33,14 +37,14 @@ abstract class FileUtil
     public static function write(string $path, string $content): void
     {
         $tmpname = tempnam(dirname($path), "tmp_XXXXXXXX");
-        $result = file_put_contents($tmpname, $content);
+        $result  = file_put_contents($tmpname, $content);
         if ($result === false) {
-            throw new \RuntimeException("Unable to write to tempfile {$tmpname}");
+            throw new RuntimeException("Unable to write to tempfile {$tmpname}");
         }
 
         $result = rename($tmpname, $path);
         if ($result === false) {
-            throw new \RuntimeException("Unable to rename {$tmpname} to $path");
+            throw new RuntimeException("Unable to rename {$tmpname} to $path");
         }
     }
 
@@ -61,7 +65,7 @@ abstract class FileUtil
     {
         $result = file_put_contents($path, $content);
         if ($result === false) {
-            throw new \RuntimeException("Unable to write file {$path}");
+            throw new RuntimeException("Unable to write file {$path}");
         }
     }
 }

--- a/src/Utilities/FileUtil.php
+++ b/src/Utilities/FileUtil.php
@@ -50,7 +50,6 @@ abstract class FileUtil
     }
 
     /**
-     * @param string $path
      * @param string[] $lines
      */
     public static function writeLines(string $path, array $lines): void

--- a/tests/functional/Services/StatsMetadataServiceTest.php
+++ b/tests/functional/Services/StatsMetadataServiceTest.php
@@ -7,6 +7,7 @@ namespace AspirePress\AspireSync\Tests\Functional\Services;
 use AspirePress\AspireSync\Services\StatsMetadataService;
 use AspirePress\AspireSync\Tests\Functional\AbstractFunctionalTestBase;
 use AspirePress\AspireSync\Tests\Helpers\FunctionalTestHelper;
+use function Safe\json_decode;
 
 class StatsMetadataServiceTest extends AbstractFunctionalTestBase
 {

--- a/tests/functional/Services/StatsMetadataServiceTest.php
+++ b/tests/functional/Services/StatsMetadataServiceTest.php
@@ -7,6 +7,7 @@ namespace AspirePress\AspireSync\Tests\Functional\Services;
 use AspirePress\AspireSync\Services\StatsMetadataService;
 use AspirePress\AspireSync\Tests\Functional\AbstractFunctionalTestBase;
 use AspirePress\AspireSync\Tests\Helpers\FunctionalTestHelper;
+
 use function Safe\json_decode;
 
 class StatsMetadataServiceTest extends AbstractFunctionalTestBase

--- a/tests/functional/Services/SvnServiceTest.php
+++ b/tests/functional/Services/SvnServiceTest.php
@@ -6,12 +6,13 @@ namespace AspirePress\AspireSync\Tests\Functional\Services;
 
 use AspirePress\AspireSync\Services\SvnService;
 use AspirePress\AspireSync\Tests\Functional\AbstractFunctionalTestBase;
+use GuzzleHttp\Client as GuzzleClient;
 
 class SvnServiceTest extends AbstractFunctionalTestBase
 {
     public function testPullingPluginsResultsInListOfPlugins(): void
     {
-        $sut    = new SvnService();
+        $sut    = new SvnService(new GuzzleClient());
         $result = $sut->getRevisionForType('plugins', 3164521, 3164522);
         $this->assertTrue($result['revision'] >= 3164522);
         $this->assertTrue(count($result['items']) >= 3);
@@ -21,7 +22,7 @@ class SvnServiceTest extends AbstractFunctionalTestBase
 
     public function testPullingThemesResultsInListOfThemes(): void
     {
-        $sut    = new SvnService();
+        $sut    = new SvnService(new GuzzleClient());
         $result = $sut->getRevisionForType('themes', 244539, 244540);
         $this->assertTrue($result['revision'] >= 244540);
         $this->assertTrue(count($result['items']) >= 1);
@@ -31,7 +32,7 @@ class SvnServiceTest extends AbstractFunctionalTestBase
 
     public function testRevisionEqualityResultsInNoSvnPull(): void
     {
-        $sut    = new SvnService();
+        $sut    = new SvnService(new GuzzleClient());
         $result = $sut->getRevisionForType('plugins', 3164522, 3164522);
         $this->assertTrue($result['revision'] === 3164522);
         $this->assertTrue(count($result['items']) === 0);


### PR DESCRIPTION
# Pull Request

## What changed?

* Made the Guzzle client an injectable service, using short (5s) timeouts and retries.

* Changed RevisionMetadataService so it no longer references a nonexistent `id` column.  Furthermore, it no longer attempts to update any existing revision rows, but always appends a new revision and only reads the latest revisions for each action.

* Replace the use of flysystem for local files with static methods on FileUtils.  Flysystem has mysterious race conditions in local filesystems that don't exist when using built-in functions.

* Bring in thecodingmachine/safe and a phpstan rule to enforce its use.

## Why did it change?

Trying to make meta:import:plugins work.  

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.