### PR TITLE
change all tables to be prefixed with sync_

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,11 +5,11 @@ services:
       dockerfile: docker/Dockerfile
       target: devbuild
     environment:
-      DB_HOST: db.aspiredev.org
-      DB_NAME: aspirecloud
-      DB_USER: postgres
-      DB_PASS: password
-      DB_SCHEMA: public
+      DB_HOST: ${DB_HOST:-db.aspiredev.org}
+      DB_NAME: ${DB_NAME:-aspirecloud}
+      DB_USER: ${DB_USER:-postgres}
+      DB_PASS: ${DB_PASS:-password}
+      DB_SCHEMA: ${DB_SCHEMA:-public}
     networks:
       - app-net
       - aspire-net

--- a/src/Services/Plugins/PluginMetadataService.php
+++ b/src/Services/Plugins/PluginMetadataService.php
@@ -480,13 +480,13 @@ class PluginMetadataService implements MetadataInterface
      */
     public function getNotFoundPlugins(): array
     {
-        $sql = "SELECT item_slug FROM not_found_items WHERE item_type = 'plugin'";
+        $sql = "SELECT item_slug FROM sync_not_found_items WHERE item_type = 'plugin'";
         return $this->pdo->fetchCol($sql);
     }
 
     public function isNotFound(string $item, bool $noLimit = false): bool
     {
-        $sql = "SELECT COUNT(*) FROM not_found_items WHERE item_slug = :item AND item_type = 'plugin'";
+        $sql = "SELECT COUNT(*) FROM sync_not_found_items WHERE item_slug = :item AND item_type = 'plugin'";
 
         if (! $noLimit) {
             $sql .= " AND created_at > NOW() - INTERVAL '1 WEEK'";
@@ -499,10 +499,10 @@ class PluginMetadataService implements MetadataInterface
     public function markItemNotFound(string $item): void
     {
         if ($this->isNotFound($item, true)) {
-            $sql = "UPDATE not_found_items SET updated_at = NOW() WHERE item_slug = :item AND item_type = 'plugin'";
+            $sql = "UPDATE sync_not_found_items SET updated_at = NOW() WHERE item_slug = :item AND item_type = 'plugin'";
             $this->pdo->perform($sql, ['item' => $item]);
         } else {
-            $sql = "INSERT INTO not_found_items (id, item_type, item_slug) VALUES (:id, 'plugin', :item)";
+            $sql = "INSERT INTO sync_not_found_items (id, item_type, item_slug) VALUES (:id, 'plugin', :item)";
             $this->pdo->perform($sql, ['id' => Uuid::uuid7()->toString(), 'item' => $item]);
         }
     }

--- a/src/Services/RevisionMetadataService.php
+++ b/src/Services/RevisionMetadataService.php
@@ -31,7 +31,7 @@ class RevisionMetadataService
             throw new RuntimeException('You did not specify a revision for action ' . $action);
         }
         $revision = $this->currentRevision[$action]['revision'];
-        $sql      = 'INSERT INTO revisions (action, revision, added_at) VALUES (:action, :revision, NOW())';
+        $sql      = 'INSERT INTO sync_revisions (action, revision, added_at) VALUES (:action, :revision, NOW())';
         $this->pdo->perform($sql, ['action' => $action, 'revision' => $revision]);
     }
 
@@ -57,7 +57,7 @@ class RevisionMetadataService
     {
         $sql = <<<SQL
             SELECT action, revision, added_at
-            FROM (SELECT *, row_number() OVER (PARTITION by action ORDER BY added_at DESC) AS rownum FROM revisions) revs
+            FROM (SELECT *, row_number() OVER (PARTITION by action ORDER BY added_at DESC) AS rownum FROM sync_revisions) revs
             WHERE revs.rownum = 1;
             SQL;
         foreach ($this->pdo->fetchAll($sql) as $revision) {

--- a/src/Services/StatsMetadataService.php
+++ b/src/Services/StatsMetadataService.php
@@ -22,7 +22,7 @@ class StatsMetadataService
     {
         $id    = Uuid::uuid7();
         $stats = json_encode($stats);
-        $sql   = 'INSERT INTO stats(id, stats, command, created_at) VALUES (:id, :stats, :command, NOW())';
+        $sql   = 'INSERT INTO sync_stats(id, stats, command, created_at) VALUES (:id, :stats, :command, NOW())';
         $this->pdo->perform($sql, ['id' => $id->toString(), 'stats' => $stats, 'command' => $command]);
     }
 }

--- a/src/Services/SvnService.php
+++ b/src/Services/SvnService.php
@@ -78,7 +78,7 @@ class SvnService implements SvnServiceInterface
         $filename = "/opt/aspiresync/data/raw-svn-$type-list";
         $tmpname  = $filename . ".tmp";
         if (file_exists($filename) && filemtime($filename) > time() - 86400) {
-            $items    = $fs->read($filename);
+            $items    = FileUtil::read($filename);
             $contents = $items;
         } else {
             try {

--- a/src/Services/Themes/ThemesMetadataService.php
+++ b/src/Services/Themes/ThemesMetadataService.php
@@ -383,13 +383,13 @@ class ThemesMetadataService
      */
     public function getNotFoundThemes(): array
     {
-        $sql = "SELECT item_slug FROM not_found_items WHERE item_type = 'theme'";
+        $sql = "SELECT item_slug FROM sync_not_found_items WHERE item_type = 'theme'";
         return $this->pdo->fetchAll($sql);
     }
 
     public function isNotFound(string $item, bool $noLimit = false): bool
     {
-        $sql = "SELECT COUNT(*) FROM not_found_items WHERE item_slug = :item AND item_type = 'theme'";
+        $sql = "SELECT COUNT(*) FROM sync_not_found_items WHERE item_slug = :item AND item_type = 'theme'";
 
         if (! $noLimit) {
             $sql .= " AND created_at > NOW() - INTERVAL '1 WEEK'";
@@ -402,10 +402,10 @@ class ThemesMetadataService
     public function markItemNotFound(string $item): void
     {
         if ($this->isNotFound($item, true)) {
-            $sql = "UPDATE not_found_items SET updated_at = NOW() WHERE item_slug = :item AND item_type = 'theme'";
+            $sql = "UPDATE sync_not_found_items SET updated_at = NOW() WHERE item_slug = :item AND item_type = 'theme'";
             $this->pdo->perform($sql, ['item' => $item]);
         } else {
-            $sql = "INSERT INTO not_found_items (id, item_type, item_slug) VALUES (:id, 'theme', :item)";
+            $sql = "INSERT INTO sync_not_found_items (id, item_type, item_slug) VALUES (:id, 'theme', :item)";
             $this->pdo->perform($sql, ['id' => Uuid::uuid7()->toString(), 'item' => $item]);
         }
     }

--- a/src/Services/Themes/ThemesMetadataService.php
+++ b/src/Services/Themes/ThemesMetadataService.php
@@ -41,7 +41,7 @@ class ThemesMetadataService
      */
     private function loadExistingThemes(): array
     {
-        $sql    = 'SELECT slug, pulled_at FROM themes';
+        $sql    = 'SELECT slug, pulled_at FROM sync_themes';
         $result = [];
         foreach ($this->pdo->fetchAll($sql) as $row) {
             $result[$row['slug']] = ['pulled_at' => $row['pulled_at']];
@@ -83,7 +83,7 @@ class ThemesMetadataService
                 'finalized' => null,
             ];
 
-            $sql = 'INSERT INTO themes (id, name, slug, current_version, updated, pulled_at, metadata) VALUES (:id, :name, :slug, :current_version, :updated_at, :pulled_at, :metadata)';
+            $sql = 'INSERT INTO sync_themes (id, name, slug, current_version, updated, pulled_at, metadata) VALUES (:id, :name, :slug, :current_version, :updated_at, :pulled_at, :metadata)';
             $this->pdo->perform($sql, [
                 'id'              => $id->toString(),
                 'name'            => $name,
@@ -122,7 +122,7 @@ class ThemesMetadataService
         $this->pdo->beginTransaction();
 
         try {
-            $mdSql      = 'SELECT id, metadata FROM themes WHERE slug = :slug';
+            $mdSql      = 'SELECT id, metadata FROM sync_themes WHERE slug = :slug';
             $result     = $this->pdo->fetchOne($mdSql, ['slug' => $fileContents['slug']]);
             $metadata   = json_decode($result['metadata'], true);
             $id         = Uuid::fromString($result['id']);
@@ -143,7 +143,7 @@ class ThemesMetadataService
             $versions       = $fileContents['versions'];
             $updatedAt      = date('c', strtotime($fileContents['last_updated']));
 
-            $sql = 'UPDATE themes SET metadata = :metadata, name = :name, current_version = :current_version, updated = :updated, pulled_at = :pulled_at WHERE slug = :slug';
+            $sql = 'UPDATE sync_themes SET metadata = :metadata, name = :name, current_version = :current_version, updated = :updated, pulled_at = :pulled_at WHERE slug = :slug';
             $this->pdo->perform($sql, [
                 'name'            => $name,
                 'slug'            => $slug,
@@ -181,7 +181,7 @@ class ThemesMetadataService
      */
     public function writeVersionProcessed(UuidInterface $themeId, array $versions, string $hash, string $cdn = 'wp_cdn'): array
     {
-        $sql = 'INSERT INTO theme_files (id, theme_id, file_url, type, version, created, processed, hash) VALUES (:id, :theme_id, :file_url, :type, :version, NOW(), NOW(), :hash)';
+        $sql = 'INSERT INTO sync_theme_files (id, theme_id, file_url, type, version, created, processed, hash) VALUES (:id, :theme_id, :file_url, :type, :version, NOW(), NOW(), :hash)';
 
         if (! $this->pdo->inTransaction()) {
             $ourTransaction = true;
@@ -219,7 +219,7 @@ class ThemesMetadataService
      */
     public function writeVersionsForTheme(UuidInterface $themeId, array $versions, string $cdn = 'wp_cdn'): array
     {
-        $sql = 'INSERT INTO theme_files (id, theme_id, file_url, type, version, created) VALUES (:id, :theme_id, :file_url, :type, :version, NOW())';
+        $sql = 'INSERT INTO sync_theme_files (id, theme_id, file_url, type, version, created) VALUES (:id, :theme_id, :file_url, :type, :version, NOW())';
 
         if (! $this->pdo->inTransaction()) {
             $ourTransaction = true;
@@ -256,7 +256,7 @@ class ThemesMetadataService
      */
     private function getNewlyDiscoveredVersionsList(UuidInterface $id, array $versions): array
     {
-        $existingVersions = "SELECT version FROM theme_files WHERE type = 'wp_cdn' AND theme_id = :id";
+        $existingVersions = "SELECT version FROM sync_theme_files WHERE type = 'wp_cdn' AND theme_id = :id";
         $existingVersions = $this->pdo->fetchCol($existingVersions, ['id' => $id->toString()]);
 
         $newVersions = [];
@@ -275,7 +275,7 @@ class ThemesMetadataService
      */
     public function getUnprocessedVersions(string $theme, array $versions, string $type = 'wp_cdn'): array
     {
-        $sql     = 'SELECT version FROM theme_files LEFT JOIN themes ON themes.id = theme_files.theme_id WHERE type = :type AND themes.slug = :theme AND processed IS NULL AND theme_files.version IN (:versions)';
+        $sql     = 'SELECT version FROM sync_theme_files LEFT JOIN sync_themes ON sync_themes.id = sync_theme_files.theme_id WHERE type = :type AND sync_themes.slug = :theme AND processed IS NULL AND sync_theme_files.version IN (:versions)';
         $results = $this->pdo->fetchAll($sql, ['theme' => $theme, 'type' => $type, 'versions' => $versions]);
         $return  = [];
         foreach ($results as $result) {
@@ -291,7 +291,7 @@ class ThemesMetadataService
     public function getDownloadUrlsForVersions(string $theme, array $versions, string $type = 'wp_cdn'): array
     {
         try {
-            $sql = 'SELECT version, file_url FROM theme_files LEFT JOIN themes ON themes.id = theme_files.theme_id WHERE themes.slug = :theme AND theme_files.type = :type AND version IN (:versions)';
+            $sql = 'SELECT version, file_url FROM sync_theme_files LEFT JOIN sync_themes ON sync_themes.id = sync_theme_files.theme_id WHERE sync_themes.slug = :theme AND sync_theme_files.type = :type AND version IN (:versions)';
 
             $results = $this->pdo->fetchAll($sql, ['theme' => $theme, 'type' => $type, 'versions' => $versions]);
             $return  = [];
@@ -312,7 +312,7 @@ class ThemesMetadataService
         $notFound = $this->getNotFoundThemes();
 
         try {
-            $sql  = "SELECT themes.id, slug, version FROM theme_files LEFT JOIN themes ON themes.id = theme_files.theme_id WHERE theme_files.type = :type";
+            $sql  = "SELECT sync_themes.id, slug, version FROM sync_theme_files LEFT JOIN sync_themes ON sync_themes.id = sync_theme_files.theme_id WHERE sync_theme_files.type = :type";
             $args = ['type' => $type];
             if ($revDate) {
                 $sql            .= ' AND themes.pulled_at >= :revDate';
@@ -335,7 +335,7 @@ class ThemesMetadataService
 
     public function setVersionToDownloaded(string $theme, string $version, ?string $hash = null, string $type = 'wp_cdn'): void
     {
-        $sql = 'UPDATE theme_files SET processed = NOW(), hash = :hash WHERE version = :version AND type = :type AND theme_id = (SELECT id FROM themes WHERE slug = :theme)';
+        $sql = 'UPDATE sync_theme_files SET processed = NOW(), hash = :hash WHERE version = :version AND type = :type AND theme_id = (SELECT id FROM sync_themes WHERE slug = :theme)';
         $this->pdo->perform($sql, ['theme' => $theme, 'type' => $type, 'hash' => $hash, 'version' => $version]);
     }
 
@@ -344,7 +344,7 @@ class ThemesMetadataService
      */
     public function getVersionData(string $themeId, ?string $version, string $type = 'wp_cdn'): array|bool
     {
-        $sql  = 'SELECT * FROM theme_files WHERE theme_id = :theme_id AND type = :type';
+        $sql  = 'SELECT * FROM sync_theme_files WHERE theme_id = :theme_id AND type = :type';
         $args = [
             'theme_id' => $themeId,
             'type'     => $type,
@@ -364,10 +364,10 @@ class ThemesMetadataService
     public function getData(array $filterBy = []): array
     {
         if (! empty($filterBy)) {
-            $sql    = "SELECT id, slug FROM themes WHERE slug IN (:themes)";
+            $sql    = "SELECT id, slug FROM sync_themes WHERE slug IN (:themes)";
             $themes = $this->pdo->fetchAll($sql, ['themes' => $filterBy]);
         } else {
-            $sql    = "SELECT id, slug FROM themes";
+            $sql    = "SELECT id, slug FROM sync_themes";
             $themes = $this->pdo->fetchAll($sql);
         }
         $result = [];
@@ -422,7 +422,7 @@ class ThemesMetadataService
 
     public function getHashForId(string $themeId, string $version): string
     {
-        $sql       = "SELECT hash FROM theme_files WHERE theme_id = :item_id AND version = :version AND type = 'wp_cdn'";
+        $sql       = "SELECT hash FROM sync_theme_files WHERE theme_id = :item_id AND version = :version AND type = 'wp_cdn'";
         $hashArray = $this->pdo->fetchOne($sql, ['item_id' => $themeId, 'version' => $version]);
         return $hashArray['hash'] ?? '';
     }

--- a/tests/functional/Services/Plugins/PluginMetadataServiceTest.php
+++ b/tests/functional/Services/Plugins/PluginMetadataServiceTest.php
@@ -85,11 +85,11 @@ class PluginMetadataServiceTest extends AbstractFunctionalTestBase
         $this->assertEmpty($data);
 
         $db     = FunctionalTestHelper::getDb();
-        $result = $db->fetchAll('SELECT * FROM plugins');
+        $result = $db->fetchAll('SELECT * FROM sync_plugins');
         $this->assertCount(1, $result);
         $this->assertEquals('closed', $result[0]['status']);
 
-        $result = $db->fetchOne('SELECT COUNT(*) as count FROM plugin_files');
+        $result = $db->fetchOne('SELECT COUNT(*) as count FROM sync_plugin_files');
         $this->assertEquals(0, $result['count']);
     }
 

--- a/tests/functional/Services/StatsMetadataServiceTest.php
+++ b/tests/functional/Services/StatsMetadataServiceTest.php
@@ -21,7 +21,7 @@ class StatsMetadataServiceTest extends AbstractFunctionalTestBase
         $sut->logStats($command, $stats);
 
         $db      = FunctionalTestHelper::getDb();
-        $statsDb = $db->fetchAll('SELECT * FROM stats');
+        $statsDb = $db->fetchAll('SELECT * FROM sync_stats');
         $this->assertCount(1, $statsDb);
         $statsCheck   = json_decode($statsDb[0]['stats'], true);
         $commandCheck = $statsDb[0]['command'];

--- a/tests/helpers/FunctionalTestHelper.php
+++ b/tests/helpers/FunctionalTestHelper.php
@@ -33,10 +33,10 @@ abstract class FunctionalTestHelper
     public static function resetDatabase(): void
     {
         $pdo = self::getDb();
-        $pdo->perform('TRUNCATE plugins CASCADE');
-        $pdo->perform('TRUNCATE themes CASCADE');
-        $pdo->perform('TRUNCATE revisions CASCADE');
-        $pdo->perform('TRUNCATE stats CASCADE');
-        $pdo->perform('TRUNCATE not_found_items CASCADE');
+        $pdo->perform('TRUNCATE sync_plugins CASCADE');
+        $pdo->perform('TRUNCATE sync_themes CASCADE');
+        $pdo->perform('TRUNCATE sync_revisions CASCADE');
+        $pdo->perform('TRUNCATE sync_stats CASCADE');
+        $pdo->perform('TRUNCATE sync_not_found_items CASCADE');
     }
 }


### PR DESCRIPTION
# Pull Request

## What changed?

All database tables used by AspireSync are now prefixed with `sync_` 

## Why did it change?

AspireCloud is going to use the unprefixed names for the full plugin and theme tables.   

## Did you fix any specific issues?

none in this repo, but related to AspirePress/AspireCloud#64 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.