### PR TITLE
File Metadata parser for eventual first-party use (+gardening)

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -1,0 +1,34 @@
+name: Commit Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - name: Install Composer dependencies
+        run: composer install
+
+      - name: Create .env file
+        run: cp .env.dist .env
+
+      - name: Create App Key
+        run: php artisan key:generate
+
+      - name: Run tests
+        run: |
+          composer run style:check
+          composer run phpstan
+          composer run test

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -24,9 +24,6 @@ jobs:
       - name: Create .env file
         run: cp .env.dist .env
 
-      - name: Create App Key
-        run: php artisan key:generate
-
       - name: Run tests
         run: |
           composer run style:check

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -18,14 +18,13 @@ jobs:
         with:
           php-version: '8.3'
 
-      - name: Install Composer dependencies
-        run: composer install
+      - name: Build Dependencies
+        run: |
+          cp .env.dist .env
+          composer install
 
-      - name: Create .env file
-        run: cp .env.dist .env
-
+      # not running phpcs right now, it's going to be replaced by php-cs-fixer soon
       - name: Run tests
         run: |
-          composer run style:check
           composer run phpstan
           composer run test

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     }
   },
   "scripts": {
-    "phpstan": "phpstan --verbose --mmory-limit=2G",
+    "phpstan": "phpstan --verbose --memory-limit=2G",
     "phpunit": "phpunit",
     "phpcs": "phpcs --parallel=4",
     "phpcbf": "phpcbf --parallel=4",

--- a/config/services.php
+++ b/config/services.php
@@ -22,7 +22,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     global $APP_DIR;
-    $env = fn(string $name, mixed $default = null) => ($_ENV[$name] ?? null) ?: $default;
+    $env = fn(string $name, mixed $default = null) => $_ENV[$name] ?? null ?: $default;
 
     $downloads_dir = $env('DOWNLOADS_DIR', "$APP_DIR/data/download");
     if (! str_starts_with($downloads_dir, '/')) {
@@ -70,5 +70,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->alias('fs.adapter.local', LocalFilesystemAdapter::class);
 
     $services->set(Filesystem::class)->args([expr("service('fs.adapter.' ~ parameter('fstype'))")]);
-
 };

--- a/src/Commands/AbstractBaseCommand.php
+++ b/src/Commands/AbstractBaseCommand.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace AspirePress\AspireSync\Commands;
 
 use AspirePress\AspireSync\Utilities\ErrorWritingTrait;
-use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +20,7 @@ abstract class AbstractBaseCommand extends Command
     public LoggerInterface $log;
 
     private ?float $startTime = null;
-    private ?float $endTime = null;
+    private ?float $endTime   = null;
 
     protected function startTimer(): void
     {

--- a/src/Commands/AbstractBaseCommand.php
+++ b/src/Commands/AbstractBaseCommand.php
@@ -42,6 +42,7 @@ abstract class AbstractBaseCommand extends Command
         $this->io = new SymfonyStyle($input, $output);
     }
 
+    /** @return array{name: string|null, startTime: float|null, elapsed: float|null} */
     protected function getDebugContext(): array
     {
         return ['name' => $this->getName(), 'startTime' => $this->startTime, 'elapsed' => $this->getElapsedTime()];

--- a/src/Commands/Download/AbstractDownloadCommand.php
+++ b/src/Commands/Download/AbstractDownloadCommand.php
@@ -71,6 +71,11 @@ abstract class AbstractDownloadCommand extends AbstractBaseCommand
         return Command::SUCCESS;
     }
 
+
+    /**
+     * @param array<string, string[]> $pending Array with slugs as keys and versions as values.
+     * @return Generator<array{string, string}> yields [$slug, $version]
+     */
     protected function generateSlugsAndVersions(array $pending, string $numVersions): Generator
     {
         foreach ($pending as $slug => $versions) {

--- a/src/Commands/Download/DownloadThemesSingleCommand.php
+++ b/src/Commands/Download/DownloadThemesSingleCommand.php
@@ -41,9 +41,7 @@ class DownloadThemesSingleCommand extends AbstractBaseCommand
             return Command::FAILURE;
         }
 
-        $response = $this->downloadService->downloadOne($slug, $version, $force);
-        // TODO: fire a ThemeDownloaded event with response
-        $this->always("{$response['url']} {$response['status']} {$response['message']}");
+        $this->downloadService->downloadBatch([[$slug, $version]], $force);
 
         return Command::SUCCESS;
     }

--- a/src/Commands/Meta/AbstractMetaSyncCommand.php
+++ b/src/Commands/Meta/AbstractMetaSyncCommand.php
@@ -142,7 +142,7 @@ abstract class AbstractMetaSyncCommand extends AbstractBaseCommand
 
     protected function onError(Exception $exception): void
     {
-        if (!($exception instanceof RequestException)) {
+        if (! $exception instanceof RequestException) {
             $this->error($exception->getMessage());
             return;
         }

--- a/src/Commands/Meta/AbstractMetaSyncCommand.php
+++ b/src/Commands/Meta/AbstractMetaSyncCommand.php
@@ -101,9 +101,14 @@ abstract class AbstractMetaSyncCommand extends AbstractBaseCommand
         return Command::SUCCESS;
     }
 
+    /**
+     * @param string[] $slugs
+     * @return Generator<Request>
+     */
     protected function generateRequests(array $slugs): Generator
     {
         foreach ($slugs as $slug) {
+
             yield $this->makeRequest((string) $slug);
         }
     }

--- a/src/Commands/Meta/MetaSyncPluginsCommand.php
+++ b/src/Commands/Meta/MetaSyncPluginsCommand.php
@@ -21,7 +21,7 @@ class MetaSyncPluginsCommand extends AbstractMetaSyncCommand
         parent::__construct($listService, $meta, $api, ResourceType::Plugin);
     }
 
-    protected function makeRequest($slug): Request
+    protected function makeRequest(string $slug): Request
     {
         return new PluginRequest($slug);
     }

--- a/src/Commands/Meta/MetaSyncThemesCommand.php
+++ b/src/Commands/Meta/MetaSyncThemesCommand.php
@@ -21,7 +21,7 @@ class MetaSyncThemesCommand extends AbstractMetaSyncCommand
         parent::__construct($listService, $meta, $api, ResourceType::Theme);
     }
 
-    protected function makeRequest($slug): Request
+    protected function makeRequest(string $slug): Request
     {
         return new ThemeRequest($slug);
     }

--- a/src/Factories/ConnectionFactory.php
+++ b/src/Factories/ConnectionFactory.php
@@ -29,7 +29,7 @@ class ConnectionFactory
         } catch (TableNotFoundException) {
             $init_script = file_get_contents($db_init_file);
             // $connection->executeQuery($init_script); // silently fails!
-            $connection->getNativeConnection()->exec($init_script);
+            $connection->getNativeConnection()->exec($init_script); // @phpstan-ignore method.nonObject
             $connection->executeQuery("select 666 from sync limit 1");
         }
         return $connection;

--- a/src/Factories/LoggerFactory.php
+++ b/src/Factories/LoggerFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Factories;
@@ -7,12 +8,12 @@ use AspirePress\AspireSync\Services\JsonLogger;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-class LoggerFactory {
+class LoggerFactory
+{
     public function __invoke(
         #[Autowire(param: 'log_file')] string $file,
         #[Autowire(param: 'log_level')] string $level,
-    ): LoggerInterface
-    {
+    ): LoggerInterface {
         return new JsonLogger($file, strtolower($level));
     }
 }

--- a/src/Integrations/Wordpress/WordpressApiConnector.php
+++ b/src/Integrations/Wordpress/WordpressApiConnector.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace AspirePress\AspireSync\Integrations\Wordpress;
 
 use Saloon\Http\Connector;
-use Saloon\RateLimitPlugin\Contracts\RateLimitStore;
-use Saloon\RateLimitPlugin\Limit;
-use Saloon\RateLimitPlugin\Stores\MemoryStore;
-use Saloon\RateLimitPlugin\Traits\HasRateLimits;
 use Saloon\Traits\Plugins\HasTimeout;
 
 class WordpressApiConnector extends Connector
 {
     use HasTimeout;
+
     // use HasRateLimits;   // too buggy with async requests to be at all usable
 
     protected int $connectTimeout = 10;

--- a/src/Integrations/Wordpress/WordpressDownloadConnector.php
+++ b/src/Integrations/Wordpress/WordpressDownloadConnector.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace AspirePress\AspireSync\Integrations\Wordpress;
 
 use Saloon\Http\Connector;
-use Saloon\RateLimitPlugin\Contracts\RateLimitStore;
-use Saloon\RateLimitPlugin\Limit;
-use Saloon\RateLimitPlugin\Stores\MemoryStore;
-use Saloon\RateLimitPlugin\Traits\HasRateLimits;
 use Saloon\Traits\Plugins\HasTimeout;
 
 class WordpressDownloadConnector extends Connector
 {
     use HasTimeout;
+
     // use HasRateLimits;   // too buggy with async requests to be at all usable
 
     protected int $connectTimeout = 10;
@@ -31,7 +28,8 @@ class WordpressDownloadConnector extends Connector
         ];
     }
 
-    protected function defaultConfig(): array {
+    protected function defaultConfig(): array
+    {
         return ['allow_redirects' => true];
     }
 }

--- a/src/ResourceType.php
+++ b/src/ResourceType.php
@@ -7,7 +7,7 @@ namespace AspirePress\AspireSync;
 enum ResourceType: string
 {
     case Plugin = 'plugin';
-    case Theme = 'theme';
+    case Theme  = 'theme';
 
     public function plural(): string
     {

--- a/src/Services/Download/AbstractDownloadService.php
+++ b/src/Services/Download/AbstractDownloadService.php
@@ -29,6 +29,7 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
 
     abstract protected function getCategory(): string;
 
+    /** @return array<string, ?int> */
     private function getFileListings(): array
     {
         return ArrayUtil::fromEntries(
@@ -37,6 +38,7 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
         );
     }
 
+    /** @param iterable<array{string, string}> $slugsAndVersions */
     public function downloadBatch(iterable $slugsAndVersions, bool $force = false): void
     {
         $pool    = $this->connector->pool(
@@ -87,6 +89,7 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
         }
     }
 
+    /** @param iterable<array{string, string}> $slugsAndVersions */
     private function generateRequests(iterable $slugsAndVersions, bool $force): Generator
     {
         $category = $this->getCategory();

--- a/src/Services/Download/DownloadServiceInterface.php
+++ b/src/Services/Download/DownloadServiceInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Services\Download;
 
-use Closure;
-
 interface DownloadServiceInterface
 {
     public function downloadBatch(iterable $slugsAndVersions, bool $force = false): void;

--- a/src/Services/Download/DownloadServiceInterface.php
+++ b/src/Services/Download/DownloadServiceInterface.php
@@ -6,5 +6,6 @@ namespace AspirePress\AspireSync\Services\Download;
 
 interface DownloadServiceInterface
 {
+    /** @param iterable<array{string, string}> $slugsAndVersions */
     public function downloadBatch(iterable $slugsAndVersions, bool $force = false): void;
 }

--- a/src/Services/Interfaces/CacheServiceInterface.php
+++ b/src/Services/Interfaces/CacheServiceInterface.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AspirePress\AspireSync\Services\Interfaces;
 
 use Closure;
 
-interface CacheServiceInterface {
+interface CacheServiceInterface
+{
     public function remember(string $key, int $ttl, Closure $callback): mixed;
 
     public function forget(string $key): void;

--- a/src/Services/Interfaces/DatabaseCacheService.php
+++ b/src/Services/Interfaces/DatabaseCacheService.php
@@ -6,12 +6,12 @@ namespace AspirePress\AspireSync\Services\Interfaces;
 
 use Closure;
 use Doctrine\DBAL\Connection;
+
 use function Safe\json_decode;
 use function Safe\json_encode;
 
 class DatabaseCacheService implements CacheServiceInterface
 {
-
     private string $table = 'cache';
 
     public function __construct(private Connection $connection)
@@ -21,14 +21,14 @@ class DatabaseCacheService implements CacheServiceInterface
     public function remember(string $key, int $ttl, Closure $callback): mixed
     {
         $conn = $this->connection;
-        $sql = "select value from {$this->table} where key = :key and expires > current_timestamp";
+        $sql  = "select value from {$this->table} where key = :key and expires > current_timestamp";
 
         $row = $conn->fetchAssociative($sql, ['key' => $key]);
         if ($row) {
             return json_decode($row['value'], true);
         }
 
-        $value = $callback();
+        $value   = $callback();
         $expires = date('c', strtotime("+$ttl seconds"));
 
         $conn->beginTransaction();

--- a/src/Services/Interfaces/SubversionServiceInterface.php
+++ b/src/Services/Interfaces/SubversionServiceInterface.php
@@ -6,13 +6,9 @@ namespace AspirePress\AspireSync\Services\Interfaces;
 
 interface SubversionServiceInterface
 {
-    /**
-     * @return array{revision: int, items: array<string, array<int, string>>}
-     */
+    /** @return array{slugs: array<string, string[]>, revision: int} */
     public function getUpdatedSlugs(string $type, int $prevRevision, int $lastRevision): array;
 
-    /**
-     * @return array{revision: int, items: array<string, array<int, string>>}
-     */
+    /** @return array{slugs: string[], revision: int} */
     public function scrapeSlugsFromIndex(string $type): array;
 }

--- a/src/Services/JsonLogger.php
+++ b/src/Services/JsonLogger.php
@@ -42,10 +42,10 @@ class JsonLogger extends AbstractLogger
         if (static::LEVELS[$this->threshold] < static::LEVELS[$level]) {
             return;
         }
-        $timestamp = (new DateTime())->format($this->dateFormat);
-        $record = compact('timestamp', 'level', 'message');
+        $timestamp                      = (new DateTime())->format($this->dateFormat);
+        $record                         = compact('timestamp', 'level', 'message');
         $context and $record['context'] = $context;
-        $json      = json_encode($record, JSON_THROW_ON_ERROR|JSON_UNESCAPED_SLASHES);
+        $json                           = json_encode($record, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
         $this->writeToLogFile($json . PHP_EOL);
     }
 
@@ -71,7 +71,6 @@ class JsonLogger extends AbstractLogger
             $level = min($level, static::LEVELS['debug']);
             $level = max($level, static::LEVELS['emergency']);
             $level = $keys[$level]; // convert to string
-
         }
         $level = strtolower($level);
         // an unrecognized level string does turn into 'debug'. we can't safely guess otherwise.

--- a/src/Services/JsonLogger.php
+++ b/src/Services/JsonLogger.php
@@ -22,7 +22,7 @@ class JsonLogger extends AbstractLogger
 
     protected string $logFile;
 
-    /** @var resource */
+    /** @var resource|null */
     protected $fileHandle;
 
     public const LEVELS = [

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Services\List;
 
-use AspirePress\AspireSync\Services\List\ListServiceInterface;
-use AspirePress\AspireSync\Services\Metadata\MetadataServiceInterface;
 use AspirePress\AspireSync\Services\Interfaces\RevisionMetadataServiceInterface;
 use AspirePress\AspireSync\Services\Interfaces\SubversionServiceInterface;
+use AspirePress\AspireSync\Services\List\ListServiceInterface;
+use AspirePress\AspireSync\Services\Metadata\MetadataServiceInterface;
 
 readonly abstract class AbstractListService implements ListServiceInterface
 {

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -6,7 +6,6 @@ namespace AspirePress\AspireSync\Services\List;
 
 use AspirePress\AspireSync\Services\Interfaces\RevisionMetadataServiceInterface;
 use AspirePress\AspireSync\Services\Interfaces\SubversionServiceInterface;
-use AspirePress\AspireSync\Services\List\ListServiceInterface;
 use AspirePress\AspireSync\Services\Metadata\MetadataServiceInterface;
 
 readonly abstract class AbstractListService implements ListServiceInterface

--- a/src/Services/List/PluginListService.php
+++ b/src/Services/List/PluginListService.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Services\List;
 
-use AspirePress\AspireSync\Services\List\AbstractListService;
 use AspirePress\AspireSync\Services\Interfaces\SubversionServiceInterface;
+use AspirePress\AspireSync\Services\List\AbstractListService;
 use AspirePress\AspireSync\Services\Metadata\PluginMetadataService;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
 
 readonly class PluginListService extends AbstractListService
 {
-    public function __construct(SubversionServiceInterface $svn, PluginMetadataService $meta, RevisionMetadataService $revisions) {
+    public function __construct(SubversionServiceInterface $svn, PluginMetadataService $meta, RevisionMetadataService $revisions)
+    {
         parent::__construct($svn, $meta, $revisions, 'plugins');
     }
 }

--- a/src/Services/List/ThemeListService.php
+++ b/src/Services/List/ThemeListService.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace AspirePress\AspireSync\Services\List;
 
 use AspirePress\AspireSync\Services\List\AbstractListService;
+use AspirePress\AspireSync\Services\Metadata\ThemeMetadataService;
 use AspirePress\AspireSync\Services\RevisionMetadataService;
 use AspirePress\AspireSync\Services\SubversionService;
-use AspirePress\AspireSync\Services\Metadata\ThemeMetadataService;
 
 readonly class ThemeListService extends AbstractListService
 {

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Connection;
 use Generator;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
-use Symfony\Contracts\Service\Attribute\Required;
 
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -42,7 +41,6 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
     /** @param array<string, mixed> $metadata */
     protected function saveOpen(array $metadata): void
     {
-
         $id = Uuid::uuid7()->toString();
 
         $this->insertSync([

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -223,7 +223,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
         ];
     }
 
-    /** @param array<string, mixed> $metadata */
+    /** @param array{slug: string, metadata: mixed} $args */
     protected function insertSync(array $args): void
     {
         $args['metadata'] = json_encode($args['metadata']);

--- a/src/Services/SubversionService.php
+++ b/src/Services/SubversionService.php
@@ -16,7 +16,7 @@ class SubversionService implements SubversionServiceInterface
     {
     }
 
-    /** @return array{revision: string, slugs: string[]} */
+    /** @return array{slugs: array<string, string[]>, revision: int} */
     public function getUpdatedSlugs(string $type, int $prevRevision, int $lastRevision): array
     {
         if ($prevRevision === $lastRevision) {
@@ -51,7 +51,7 @@ class SubversionService implements SubversionServiceInterface
         return ['revision' => $revision, 'slugs' => $slugs];
     }
 
-    /** @return string[] */
+    /** @return array{slugs: string[], revision: int} */
     public function scrapeSlugsFromIndex(string $type): array
     {
         $html = $this->guzzle

--- a/src/Services/SubversionService.php
+++ b/src/Services/SubversionService.php
@@ -66,6 +66,6 @@ class SubversionService implements SubversionServiceInterface
         $slugs = array_map(urldecode(...), $slugs);
         // $slugs = array_map(fn ($slug) => (string) urldecode($slug), $slugs);
 
-        return ['slugs' => $slugs, 'revision' => (int)$revision];
+        return ['slugs' => $slugs, 'revision' => (int) $revision];
     }
 }

--- a/src/Utilities/ArrayUtil.php
+++ b/src/Utilities/ArrayUtil.php
@@ -6,11 +6,19 @@ namespace AspirePress\AspireSync\Utilities;
 
 class ArrayUtil
 {
+    /**
+     * @param array<string|int, mixed> $arr
+     * @return array{string|int, mixed}[]
+     */
     public static function entries(array $arr): array
     {
         return array_map(fn($key) => [$key, $arr[$key]], array_keys($arr));
     }
 
+    /**
+     * @param iterable<array{string|int, mixed}> $entries
+     * @return array<string|int, mixed>
+     */
     public static function fromEntries(iterable $entries): array
     {
         $assoc = [];

--- a/src/Utilities/ErrorWritingTrait.php
+++ b/src/Utilities/ErrorWritingTrait.php
@@ -31,7 +31,7 @@ trait ErrorWritingTrait
      */
     protected function writeMessage(string|iterable $message, int $level = self::ALWAYS_WRITE): void
     {
-        $this->log?->log($level, $message, ['command' => $this->getDebugContext()]);
+        $this->log->log($level, $message, ['command' => $this->getDebugContext()]);
         switch ($level) {
             case self::ERROR:
                 $this->io->writeln("<fg=black;bg=red>" . OutputManagementUtil::error($message) . "</>");

--- a/src/Utilities/RegexUtil.php
+++ b/src/Utilities/RegexUtil.php
@@ -1,16 +1,26 @@
 <?php
+
 declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Utilities;
 
 // This class is normally just named 'Regex' elsewhere, but it gets the "Util" suffix in AS for consistency.
 
-class RegexUtil {
+use Safe\Exceptions\PcreException;
+
+use function Safe\preg_grep;
+use function Safe\preg_match;
+use function Safe\preg_match_all;
+use function Safe\preg_replace;
+use function Safe\preg_split;
+
+class RegexUtil
+{
     /** @return string[] */
     public static function match(string $pattern, string $subject, int $flags = 0, int $offset = 0): array
     {
         $matches = [];
-        \Safe\preg_match($pattern, $subject, $matches, $flags, $offset);
+        preg_match($pattern, $subject, $matches, $flags, $offset);
         return $matches;
     }
 
@@ -18,7 +28,7 @@ class RegexUtil {
     public static function matchAll(string $pattern, string $subject, int $flags = 0, int $offset = 0): array
     {
         $matches = [];
-        \Safe\preg_match_all($pattern, $subject, $matches, $flags, $offset);
+        preg_match_all($pattern, $subject, $matches, $flags, $offset);
         return $matches;
     }
 
@@ -29,7 +39,7 @@ class RegexUtil {
      */
     public static function split(string $pattern, string $subject, ?int $limit = -1, int $flags = 0): array
     {
-        return \Safe\preg_split($pattern, $subject, $limit, $flags);
+        return preg_split($pattern, $subject, $limit, $flags);
     }
 
     /**
@@ -39,7 +49,34 @@ class RegexUtil {
      */
     public static function grep(string $pattern, array $array, int $flags = 0): array
     {
-        return \Safe\preg_grep($pattern, $array, $flags);
+        return preg_grep($pattern, $array, $flags);
+    }
+
+    /**
+     * Fits the most common use case of preg_replace, namely single strings.  Does not support the by-ref $count arg.
+     */
+    public static function replace(string $pattern, string $replacement, string $subject, int $limit = -1): string
+    {
+        return static::_replace($pattern, $replacement, $subject, $limit);
+    }
+
+    /**
+     * Equivalent to \Safe\preg_replace, inherits the insane signature of the builtin preg_replace
+     *
+     * @param string|string[] $pattern
+     * @param string|string[] $replacement
+     * @param string|string[] $subject
+     * @return string|string[]
+     * @throws PcreException
+     */
+    public static function _replace(
+        string|array $pattern,
+        string|array $replacement,
+        string|array $subject,
+        int $limit = -1,
+        ?int &$count = null
+    ): string|array {
+        return preg_replace($pattern, $replacement, $subject, $limit, $count);
     }
 
     private function __construct()

--- a/src/Utilities/RegexUtil.php
+++ b/src/Utilities/RegexUtil.php
@@ -45,6 +45,7 @@ class RegexUtil
     /**
      * Here for consistency: no difference from \Safe\preg_grep
      *
+     * @param string[] $array
      * @return string[]
      */
     public static function grep(string $pattern, array $array, int $flags = 0): array

--- a/src/Utilities/WP/FileHeaderParser.php
+++ b/src/Utilities/WP/FileHeaderParser.php
@@ -6,7 +6,7 @@ namespace AspirePress\AspireSync\Utilities\WP;
 
 use AspirePress\AspireSync\Utilities\RegexUtil;
 
-class FileMetadataParser
+class FileHeaderParser
 {
     public static function readPluginMetadata(string $content): array
     {

--- a/src/Utilities/WP/FileHeaderParser.php
+++ b/src/Utilities/WP/FileHeaderParser.php
@@ -8,6 +8,7 @@ use AspirePress\AspireSync\Utilities\RegexUtil;
 
 class FileHeaderParser
 {
+    /** @return array<string, string> */
     public static function readPluginHeader(string $content): array
     {
         // https://developer.wordpress.org/plugins/plugin-basics/header-requirements/
@@ -36,6 +37,7 @@ class FileHeaderParser
         return self::readHeaders($content, $headers);
     }
 
+    /** @return array<string, string> */
     public static function readThemeHeader(string $content): array
     {
         // https://developer.wordpress.org/themes/basics/main-stylesheet-style-css/#explanations
@@ -65,6 +67,10 @@ class FileHeaderParser
         return self::readHeaders($content, $headers);
     }
 
+    /**
+     * @param array<string, string> $headers
+     * @return array<string, string>
+     */
     public static function readHeaders(string $content, array $headers): array
     {
         $parsed = [];

--- a/src/Utilities/WP/FileHeaderParser.php
+++ b/src/Utilities/WP/FileHeaderParser.php
@@ -8,7 +8,7 @@ use AspirePress\AspireSync\Utilities\RegexUtil;
 
 class FileHeaderParser
 {
-    public static function readPluginMetadata(string $content): array
+    public static function readPluginHeader(string $content): array
     {
         // https://developer.wordpress.org/plugins/plugin-basics/header-requirements/
         $headers = [
@@ -33,10 +33,10 @@ class FileHeaderParser
             // 'Title'      => 'Plugin Name',     // set by parser, not a header
             // 'AuthorName' => 'Author',          // set by parser, not a header
         ];
-        return self::readMetadata($content, $headers);
+        return self::readHeaders($content, $headers);
     }
 
-    public static function readThemeMetadata(string $content): array
+    public static function readThemeHeader(string $content): array
     {
         // https://developer.wordpress.org/themes/basics/main-stylesheet-style-css/#explanations
         $headers = [
@@ -62,19 +62,19 @@ class FileHeaderParser
             'Status'    => 'Status',
             'UpdateURI' => 'Update URI',
         ];
-        return self::readMetadata($content, $headers);
+        return self::readHeaders($content, $headers);
     }
 
-    public static function readMetadata(string $content, array $headers): array
+    public static function readHeaders(string $content, array $headers): array
     {
-        $metadata = [];
+        $parsed = [];
         foreach ($headers as $field => $key) {
             $pattern = '/^(?:[ \t]*<\?php)?[ \t\/*#@]*' . $key . ':(.*)$/mi';
             $matches = RegexUtil::match($pattern, $content);
             $value   = $matches[1] ?? '';
 
-            $metadata[$field] = mb_trim(RegexUtil::replace('/\s*(?:\*\/|\?>).*/', '', $value));
+            $parsed[$field] = mb_trim(RegexUtil::replace('/\s*(?:\*\/|\?>).*/', '', $value));
         }
-        return $metadata;
+        return $parsed;
     }
 }

--- a/src/Utilities/WP/FileMetadataParser.php
+++ b/src/Utilities/WP/FileMetadataParser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AspirePress\AspireSync\Utilities\WP;
+
+use AspirePress\AspireSync\Utilities\RegexUtil;
+
+class FileMetadataParser
+{
+    public static function readPluginMetadata(string $content): array
+    {
+        $headers = [
+            'Name'            => 'Plugin Name',
+            'PluginURI'       => 'Plugin URI',
+            'Version'         => 'Version',
+            'Description'     => 'Description',
+            'Author'          => 'Author',
+            'AuthorURI'       => 'Author URI',
+            'TextDomain'      => 'Text Domain',
+            'DomainPath'      => 'Domain Path',
+            'Network'         => 'Network',
+            'RequiresWP'      => 'Requires at least',
+            'RequiresPHP'     => 'Requires PHP',
+            'UpdateURI'       => 'Update URI',
+            'RequiresPlugins' => 'Requires Plugins',
+            // Site Wide Only is deprecated in favor of Network.
+            '_sitewide' => 'Site Wide Only',
+        ];
+        return self::readMetadata($content, $headers);
+    }
+
+    public static function readMetadata(string $content, array $headers): array
+    {
+        $metadata = [];
+        foreach ($headers as $field => $key) {
+            $pattern          = '/^(?:[ \t]*<\?php)?[ \t\/*#@]*' . $key . ':(.*)$/mi';
+            $matches          = RegexUtil::match($pattern, $content);
+            $metadata[$field] = $matches ? self::_cleanup_header_comment($matches[1]) : '';
+        }
+        return $metadata;
+    }
+
+    public static function _cleanup_header_comment(string $str): string
+    {
+        return mb_trim(RegexUtil::replace('/\s*(?:\*\/|\?>).*/', '', $str));
+    }
+}

--- a/tests/stubs/MetadataServiceStub.php
+++ b/tests/stubs/MetadataServiceStub.php
@@ -43,4 +43,9 @@ class MetadataServiceStub implements MetadataServiceInterface
     {
         return [];
     }
+
+    public function markProcessed(string $slug, string $version): void
+    {
+        // nothingness
+    }
 }

--- a/tests/stubs/SubversionServiceStub.php
+++ b/tests/stubs/SubversionServiceStub.php
@@ -12,7 +12,7 @@ class SubversionServiceStub implements SubversionServiceInterface
     {
         return [
             'revision' => 123,
-            'slugs'    => ['foo', 'bar', 'baz'],
+            'slugs'    => ['foo' => [], 'bar' => [], 'baz' => []],
         ];
     }
 

--- a/tests/unit/Services/JsonLoggerTest.php
+++ b/tests/unit/Services/JsonLoggerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Tests\Unit\Services;
@@ -6,7 +7,8 @@ namespace AspirePress\AspireSync\Tests\Unit\Services;
 use AspirePress\AspireSync\Services\JsonLogger;
 use PHPUnit\Framework\TestCase;
 
-class JsonLoggerTest extends TestCase {
+class JsonLoggerTest extends TestCase
+{
     private JsonLogger $sut;
 
     protected function setUp(): void
@@ -14,19 +16,22 @@ class JsonLoggerTest extends TestCase {
         $this->sut = new JsonLogger();
     }
 
-    public function test_normalize_level(): void {
+    public function test_normalize_level(): void
+    {
         $this->assertEquals('debug', JsonLogger::normalizeLevel('debug'));
         $this->assertEquals('info', JsonLogger::normalizeLevel('INFO'));
         $this->assertEquals('emergency', JsonLogger::normalizeLevel('eMeRgEnCy'));
         $this->assertEquals('critical', JsonLogger::normalizeLevel(2));
     }
 
-    public function test_integer_levels_out_of_bounds_are_clamped(): void {
+    public function test_integer_levels_out_of_bounds_are_clamped(): void
+    {
         $this->assertEquals('debug', JsonLogger::normalizeLevel(999));
         $this->assertEquals('emergency', JsonLogger::normalizeLevel(-1));
     }
 
-    public function test_all_int_strings_are_debug(): void {
+    public function test_all_int_strings_are_debug(): void
+    {
         // TODO: check whether this violates PSR-3.  Meantime, just don't do this!
         $this->assertEquals('debug', JsonLogger::normalizeLevel('5'));
     }

--- a/tests/unit/Services/JsonLoggerTest.php
+++ b/tests/unit/Services/JsonLoggerTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class JsonLoggerTest extends TestCase
 {
-    private JsonLogger $sut;
-
-    protected function setUp(): void
-    {
-        $this->sut = new JsonLogger();
-    }
-
     public function test_normalize_level(): void
     {
         $this->assertEquals('debug', JsonLogger::normalizeLevel('debug'));

--- a/tests/unit/Utilities/WP/FileHeaderParserTest.php
+++ b/tests/unit/Utilities/WP/FileHeaderParserTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace AspirePress\AspireSync\Tests\Unit\Utilities\WP;
 
-use AspirePress\AspireSync\Utilities\WP\FileMetadataParser;
+use AspirePress\AspireSync\Utilities\WP\FileHeaderParser;
 use PHPUnit\Framework\TestCase;
 
-class FileMetadataParserTest extends TestCase
+class FileHeaderParserTest extends TestCase
 {
     public function testReadPluginMetadata(): void
     {
@@ -25,7 +25,7 @@ class FileMetadataParserTest extends TestCase
         */
         HEADER;
 
-        $metadata = FileMetadataParser::readPluginMetadata($header);
+        $metadata = FileHeaderParser::readPluginMetadata($header);
 
         $this->assertEquals('Plugin Directory', $metadata['Name']);
         $this->assertEquals('https://wordpress.org/plugins/', $metadata['PluginURI']);
@@ -65,7 +65,7 @@ class FileMetadataParserTest extends TestCase
         */
         HEADER;
 
-        $metadata = FileMetadataParser::readThemeMetadata($header);
+        $metadata = FileHeaderParser::readThemeMetadata($header);
 
         $this->assertEquals('Twenty Twenty-Five', $metadata['Name']);
         $this->assertEquals('https://wp.org/themes/twentytwentyfive/', $metadata['ThemeURI']);

--- a/tests/unit/Utilities/WP/FileHeaderParserTest.php
+++ b/tests/unit/Utilities/WP/FileHeaderParserTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class FileHeaderParserTest extends TestCase
 {
-    public function testReadPluginMetadata(): void
+    public function testReadPluginHeader(): void
     {
         $header = <<<HEADER
         /*
@@ -25,27 +25,27 @@ class FileHeaderParserTest extends TestCase
         */
         HEADER;
 
-        $metadata = FileHeaderParser::readPluginMetadata($header);
+        $headers = FileHeaderParser::readPluginHeader($header);
 
-        $this->assertEquals('Plugin Directory', $metadata['Name']);
-        $this->assertEquals('https://wordpress.org/plugins/', $metadata['PluginURI']);
-        $this->assertEquals('Transforms a WordPress site in The Official Plugin Directory.', $metadata['Description']);
-        $this->assertEquals('3.0', $metadata['Version']);
-        $this->assertEquals('the WordPress team', $metadata['Author']);
-        $this->assertEquals('https://wordpress.org/', $metadata['AuthorURI']);
-        $this->assertEquals('wporg-plugins', $metadata['TextDomain']);
-        $this->assertEquals('GPLv2', $metadata['License']);
-        $this->assertEquals('https://opensource.org/licenses/gpl-2.0.php', $metadata['LicenseURI']);
-        $this->assertEquals('', $metadata['DomainPath']);
-        $this->assertEquals('', $metadata['Network']);
-        $this->assertEquals('', $metadata['RequiresWP']);
-        $this->assertEquals('', $metadata['RequiresPHP']);
-        $this->assertEquals('', $metadata['UpdateURI']);
-        $this->assertEquals('', $metadata['RequiresPlugins']);
+        $this->assertEquals('Plugin Directory', $headers['Name']);
+        $this->assertEquals('https://wordpress.org/plugins/', $headers['PluginURI']);
+        $this->assertEquals('Transforms a WordPress site in The Official Plugin Directory.', $headers['Description']);
+        $this->assertEquals('3.0', $headers['Version']);
+        $this->assertEquals('the WordPress team', $headers['Author']);
+        $this->assertEquals('https://wordpress.org/', $headers['AuthorURI']);
+        $this->assertEquals('wporg-plugins', $headers['TextDomain']);
+        $this->assertEquals('GPLv2', $headers['License']);
+        $this->assertEquals('https://opensource.org/licenses/gpl-2.0.php', $headers['LicenseURI']);
+        $this->assertEquals('', $headers['DomainPath']);
+        $this->assertEquals('', $headers['Network']);
+        $this->assertEquals('', $headers['RequiresWP']);
+        $this->assertEquals('', $headers['RequiresPHP']);
+        $this->assertEquals('', $headers['UpdateURI']);
+        $this->assertEquals('', $headers['RequiresPlugins']);
     }
 
     /** @noinspection HttpUrlsUsage */
-    public function testThemeMetadata(): void
+    public function testThemeHeader(): void
     {
         $header = <<<HEADER
         /*
@@ -65,20 +65,20 @@ class FileHeaderParserTest extends TestCase
         */
         HEADER;
 
-        $metadata = FileHeaderParser::readThemeMetadata($header);
+        $headers = FileHeaderParser::readThemeHeader($header);
 
-        $this->assertEquals('Twenty Twenty-Five', $metadata['Name']);
-        $this->assertEquals('https://wp.org/themes/twentytwentyfive/', $metadata['ThemeURI']);
-        $this->assertEquals('the WordPress team', $metadata['Author']);
-        $this->assertEquals('https://wp.org', $metadata['AuthorURI']);
-        $this->assertStringStartsWith('Twenty Twenty-Five emphasizes simplicity and adaptability.', $metadata['Description']);
-        $this->assertEquals('6.7', $metadata['RequiresWP']);
-        $this->assertEquals('6.7', $metadata['TestedUpTo']);
-        $this->assertEquals('7.2.24', $metadata['RequiresPHP']);
-        $this->assertEquals('1.0', $metadata['Version']);
-        $this->assertEquals('GNU General Public License v2 or later', $metadata['License']);
-        $this->assertEquals('http://www.gnu.org/licenses/gpl-2.0.html', $metadata['LicenseURI']);
-        $this->assertEquals('twentytwentyfive', $metadata['TextDomain']);
-        $this->assertStringStartsWith('one-column, custom-colors, custom-menu, custom-logo, editor-style', $metadata['Tags']);
+        $this->assertEquals('Twenty Twenty-Five', $headers['Name']);
+        $this->assertEquals('https://wp.org/themes/twentytwentyfive/', $headers['ThemeURI']);
+        $this->assertEquals('the WordPress team', $headers['Author']);
+        $this->assertEquals('https://wp.org', $headers['AuthorURI']);
+        $this->assertStringStartsWith('Twenty Twenty-Five emphasizes simplicity and adaptability.', $headers['Description']);
+        $this->assertEquals('6.7', $headers['RequiresWP']);
+        $this->assertEquals('6.7', $headers['TestedUpTo']);
+        $this->assertEquals('7.2.24', $headers['RequiresPHP']);
+        $this->assertEquals('1.0', $headers['Version']);
+        $this->assertEquals('GNU General Public License v2 or later', $headers['License']);
+        $this->assertEquals('http://www.gnu.org/licenses/gpl-2.0.html', $headers['LicenseURI']);
+        $this->assertEquals('twentytwentyfive', $headers['TextDomain']);
+        $this->assertStringStartsWith('one-column, custom-colors, custom-menu, custom-logo, editor-style', $headers['Tags']);
     }
 }

--- a/tests/unit/Utilities/WP/FileMetadataParserTest.php
+++ b/tests/unit/Utilities/WP/FileMetadataParserTest.php
@@ -46,6 +46,5 @@ class FileMetadataParserTest extends TestCase
         $this->assertEquals('', $metadata['UpdateURI']);
         $this->assertEquals('', $metadata['RequiresPlugins']);
         $this->assertEquals('', $metadata['_sitewide']);
-
     }
 }

--- a/tests/unit/Utilities/WP/FileMetadataParserTest.php
+++ b/tests/unit/Utilities/WP/FileMetadataParserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AspirePress\AspireSync\Tests\Unit\Utilities\WP;
+
+use AspirePress\AspireSync\Utilities\WP\FileMetadataParser;
+use PHPUnit\Framework\TestCase;
+
+class FileMetadataParserTest extends TestCase
+{
+    public function testReadPluginMetadata(): void
+    {
+        $header = <<<HEADER
+        /*
+         * Plugin Name: Plugin Directory
+         * Plugin URI: https://wordpress.org/plugins/
+         * Description: Transforms a WordPress site in The Official Plugin Directory.
+         * Version: 3.0
+         * Author: the WordPress team
+         * Author URI: https://wordpress.org/
+         * Text Domain: wporg-plugins
+         * License: GPLv2
+         * License URI: https://opensource.org/licenses/gpl-2.0.php
+        */
+        HEADER;
+
+        $metadata = FileMetadataParser::readPluginMetadata($header);
+
+        $this->assertEquals('Plugin Directory', $metadata['Name']);
+        $this->assertEquals('https://wordpress.org/plugins/', $metadata['PluginURI']);
+        $this->assertEquals('Transforms a WordPress site in The Official Plugin Directory.', $metadata['Description']);
+        $this->assertEquals('3.0', $metadata['Version']);
+        $this->assertEquals('the WordPress team', $metadata['Author']);
+        $this->assertEquals('https://wordpress.org/', $metadata['AuthorURI']);
+        $this->assertEquals('wporg-plugins', $metadata['TextDomain']);
+
+        // upstream apparently doesn't care about licenses, as we're discovering...
+        // $this->assertEquals('GPLv2', $metadata['License']);
+        // $this->assertEquals('https://opensource.org/licenses/gpl-2.0.php', $metadata['LicenseURI']);
+
+        $this->assertEquals('', $metadata['DomainPath']);
+        $this->assertEquals('', $metadata['Network']);
+        $this->assertEquals('', $metadata['RequiresWP']);
+        $this->assertEquals('', $metadata['RequiresPHP']);
+        $this->assertEquals('', $metadata['UpdateURI']);
+        $this->assertEquals('', $metadata['RequiresPlugins']);
+        $this->assertEquals('', $metadata['_sitewide']);
+
+    }
+}

--- a/tests/unit/Utilities/WP/FileMetadataParserTest.php
+++ b/tests/unit/Utilities/WP/FileMetadataParserTest.php
@@ -34,17 +34,51 @@ class FileMetadataParserTest extends TestCase
         $this->assertEquals('the WordPress team', $metadata['Author']);
         $this->assertEquals('https://wordpress.org/', $metadata['AuthorURI']);
         $this->assertEquals('wporg-plugins', $metadata['TextDomain']);
-
-        // upstream apparently doesn't care about licenses, as we're discovering...
-        // $this->assertEquals('GPLv2', $metadata['License']);
-        // $this->assertEquals('https://opensource.org/licenses/gpl-2.0.php', $metadata['LicenseURI']);
-
+        $this->assertEquals('GPLv2', $metadata['License']);
+        $this->assertEquals('https://opensource.org/licenses/gpl-2.0.php', $metadata['LicenseURI']);
         $this->assertEquals('', $metadata['DomainPath']);
         $this->assertEquals('', $metadata['Network']);
         $this->assertEquals('', $metadata['RequiresWP']);
         $this->assertEquals('', $metadata['RequiresPHP']);
         $this->assertEquals('', $metadata['UpdateURI']);
         $this->assertEquals('', $metadata['RequiresPlugins']);
-        $this->assertEquals('', $metadata['_sitewide']);
+    }
+
+    /** @noinspection HttpUrlsUsage */
+    public function testThemeMetadata(): void
+    {
+        $header = <<<HEADER
+        /*
+        Theme Name: Twenty Twenty-Five
+        Theme URI: https://wp.org/themes/twentytwentyfive/
+        Author: the WordPress team
+        Author URI: https://wp.org
+        Description: Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible design options, supported by a variety of patterns for different page types, such as services and landing pages, making it ideal for building personal blogs, professional portfolios, online magazines, or business websites. Its templates cater to various blog styles, from text-focused to image-heavy layouts. Additionally, it supports international typography and diverse color palettes, ensuring accessibility and customization for users worldwide.
+        Requires at least: 6.7
+        Tested up to: 6.7
+        Requires PHP: 7.2.24
+        Version: 1.0
+        License: GNU General Public License v2 or later
+        License URI: http://www.gnu.org/licenses/gpl-2.0.html
+        Text Domain: twentytwentyfive
+        Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, block-styles, style-variations, accessibility-ready, blog, portfolio, news
+        */
+        HEADER;
+
+        $metadata = FileMetadataParser::readThemeMetadata($header);
+
+        $this->assertEquals('Twenty Twenty-Five', $metadata['Name']);
+        $this->assertEquals('https://wp.org/themes/twentytwentyfive/', $metadata['ThemeURI']);
+        $this->assertEquals('the WordPress team', $metadata['Author']);
+        $this->assertEquals('https://wp.org', $metadata['AuthorURI']);
+        $this->assertStringStartsWith('Twenty Twenty-Five emphasizes simplicity and adaptability.', $metadata['Description']);
+        $this->assertEquals('6.7', $metadata['RequiresWP']);
+        $this->assertEquals('6.7', $metadata['TestedUpTo']);
+        $this->assertEquals('7.2.24', $metadata['RequiresPHP']);
+        $this->assertEquals('1.0', $metadata['Version']);
+        $this->assertEquals('GNU General Public License v2 or later', $metadata['License']);
+        $this->assertEquals('http://www.gnu.org/licenses/gpl-2.0.html', $metadata['LicenseURI']);
+        $this->assertEquals('twentytwentyfive', $metadata['TextDomain']);
+        $this->assertStringStartsWith('one-column, custom-colors, custom-menu, custom-logo, editor-style', $metadata['Tags']);
     }
 }


### PR DESCRIPTION
# Pull Request

## What changed?

* Ports upstream's parser for metadata blocks in plugin and theme files
* Reformats lots of files because that's been neglected
* Fix lots of phpstan issues (mostly phpdoc)
* Adds a CI github action

## Why did it change?

Groundwork to support first-party publishing on packagist

## Did you fix any specific issues?

Partially addresses #17, does not yet close it

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

