### PR TITLE
use \Safe versions of builtin functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "require-dev": {
         "phpstan/phpstan": ">=1.12.12",
         "phpunit/phpunit": ">=11.4.4",
+        "rector/rector": "^1.2",
         "roave/security-advisories": "dev-latest",
         "symfony/maker-bundle": "^1.61",
         "thecodingmachine/phpstan-safe-rule": ">=1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c3100fd95dbe1ec75158a9a02885a37",
+    "content-hash": "c163ba055e5b80c5b5c1ffb55b51ea92",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6703,6 +6703,65 @@
                 }
             ],
             "time": "2024-11-27T10:44:52+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "1.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40f9cf38c05296bd32f444121336a521a293fa61",
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.12.5"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/1.2.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-08T13:59:10+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -6,3 +6,5 @@ parameters:
         - public/
         - src/
         - tests/
+includes:
+    - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon

--- a/src/Commands/AbstractBaseCommand.php
+++ b/src/Commands/AbstractBaseCommand.php
@@ -35,7 +35,7 @@ abstract class AbstractBaseCommand extends Command
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
-        ini_set('memory_limit', '4G');
+        \Safe\ini_set('memory_limit', '4G');
     }
 
     /** @return array{name: string|null, startTime: float|null, elapsed: float|null} */

--- a/src/Services/Download/AbstractDownloadService.php
+++ b/src/Services/Download/AbstractDownloadService.php
@@ -110,7 +110,7 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
                 $this->meta->markProcessed($slug, $version);
                 continue;
             }
-            $remotePath = preg_replace('#^https?://.*?/#', '/', $url);
+            $remotePath = \Safe\preg_replace('#^https?://.*?/#', '/', $url);
             yield new DownloadRequest($remotePath, $localPath, $slug, $version);
         }
     }

--- a/src/Services/Interfaces/DatabaseCacheService.php
+++ b/src/Services/Interfaces/DatabaseCacheService.php
@@ -29,7 +29,7 @@ class DatabaseCacheService implements CacheServiceInterface
         }
 
         $value   = $callback();
-        $expires = date('c', strtotime("+$ttl seconds"));
+        $expires = \Safe\date('c', \Safe\strtotime("+$ttl seconds"));
 
         $conn->beginTransaction();
         $conn->delete($this->table, ['key' => $key]);

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -58,7 +58,7 @@ readonly abstract class AbstractListService implements ListServiceInterface
     {
         $revision = $this->revisions->getRevisionDateForAction($this->category);
         if ($revision) {
-            $revision = date('Y-m-d', strtotime($revision));
+            $revision = \Safe\date('Y-m-d', \Safe\strtotime($revision));
         }
         return $this->filter($this->meta->getOpenVersions($revision), $requested, null);
     }

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -51,8 +51,8 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             'status'   => 'open',
             'version'  => $metadata['version'],
             'origin'   => $this->origin,
-            'updated'  => date('c', strtotime($metadata['last_updated'])),
-            'pulled'   => date('c'),
+            'updated'  => \Safe\date('c', \Safe\strtotime($metadata['last_updated'])),
+            'pulled'   => \Safe\date('c'),
             'metadata' => $metadata,
         ]);
 
@@ -85,8 +85,8 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             'status'   => $status,
             'version'  => null,
             'origin'   => $this->origin,
-            'updated'  => $metadata['closed_date'] ?? date('c'),
-            'pulled'   => date('c'),
+            'updated'  => $metadata['closed_date'] ?? \Safe\date('c'),
+            'pulled'   => \Safe\date('c'),
             'metadata' => $metadata,
         ];
         $this->insertSync($row);
@@ -217,8 +217,8 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             'status'   => $item['status'],
             'version'  => $item['version'],
             'origin'   => $item['origin'],
-            'updated'  => new DateTimeImmutable($item['updated']),
-            'pulled'   => new DateTimeImmutable($item['pulled']),
+            'updated'  => new \Safe\DateTimeImmutable($item['updated']),
+            'pulled'   => new \Safe\DateTimeImmutable($item['pulled']),
             'metadata' => json_decode($item['metadata'] ?? 'null'),
         ];
     }

--- a/src/Services/SubversionService.php
+++ b/src/Services/SubversionService.php
@@ -33,7 +33,7 @@ class SubversionService implements SubversionServiceInterface
             throw new RuntimeException("Unable to get list of $type to update: {$process->getErrorOutput()}");
         }
 
-        $output = simplexml_load_string($process->getOutput());
+        $output = \Safe\simplexml_load_string($process->getOutput());
 
         $slugs   = [];
         $entries = $output->logentry;

--- a/src/Utilities/FileUtil.php
+++ b/src/Utilities/FileUtil.php
@@ -16,11 +16,7 @@ abstract class FileUtil
 {
     public static function read(string $path): string
     {
-        $contents = file_get_contents($path);
-        if ($contents === false) {
-            throw new RuntimeException("Unable to read file {$path}");
-        }
-        return $contents;
+        return \Safe\file_get_contents($path);
     }
 
     /** @return string[] */
@@ -43,16 +39,9 @@ abstract class FileUtil
         $dir = dirname($path);
         is_dir($dir) or throw new RuntimeException("No such directory: $dir");
 
-        $tmpname = tempnam(dirname($path), "tmp_XXXXXXXX");
-        $result  = file_put_contents($tmpname, $content);
-        if ($result === false) {
-            throw new RuntimeException("Unable to write to tempfile {$tmpname}");
-        }
-
-        $result = rename($tmpname, $path);
-        if ($result === false) {
-            throw new RuntimeException("Unable to rename {$tmpname} to $path");
-        }
+        $tmpname = \Safe\tempnam(dirname($path), "tmp_XXXXXXXX");
+        \Safe\file_put_contents($tmpname, $content);
+        \Safe\rename($tmpname, $path);
     }
 
     /**
@@ -77,10 +66,7 @@ abstract class FileUtil
 
     public static function writeRaw(string $path, string $content): void
     {
-        $result = file_put_contents($path, $content);
-        if ($result === false) {
-            throw new RuntimeException("Unable to write file {$path}");
-        }
+        \Safe\file_put_contents($path, $content);
     }
 
     public static function cacheFile(string $path, int $maxAgeSecs, Closure $callback): string

--- a/src/Utilities/VersionUtil.php
+++ b/src/Utilities/VersionUtil.php
@@ -50,7 +50,7 @@ abstract class VersionUtil
     public static function cleanVersion(string $version): array
     {
         // $version = trim($version); // XXX bad idea, the data needs to be cleaned at the source.
-        if (! preg_match('/^[-A-Za-z0-9_.]+$/', $version)) {
+        if (! \Safe\preg_match('/^[-A-Za-z0-9_.]+$/', $version)) {
             $encoded = urlencode($version);
             return [null, "Invalid version [urlencoded version: $encoded]"];
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-ini_set('memory_limit', '4G');
+\Safe\ini_set('memory_limit', '4G');


### PR DESCRIPTION
# Pull Request

## What changed?

Replaces uses of builtin global functions with their \Safe equivalents and adds a phpstan rule to enforce their use.

## Why did it change?

https://eev.ee/blog/2012/04/09/php-a-fractal-of-bad-design/

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

