### PR TITLE
use php-cs-fixer for style linting

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -22,8 +22,8 @@ jobs:
         run: |
           composer install
 
-      # not running phpcs right now, it's going to be replaced by php-cs-fixer soon
       - name: Run tests
         run: |
+          composer run style:check
           composer run phpstan
           composer run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /data/
-vendor/
-.phpcs-cache
+.cache
 *.sqlite
 *.sqlite-journal
 
@@ -22,3 +21,8 @@ vendor/
 ###> phpstan/phpstan ###
 phpstan.neon
 ###< phpstan/phpstan ###
+
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
+###< friendsofphp/php-cs-fixer ###

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+$finder = (new Finder())
+    ->in(__DIR__)
+    ->exclude([
+        'vendor',
+        'storage',
+        'bootstrap',
+    ])
+    ->notPath([
+        '_ide_helper.php',
+        '.phpstorm.meta.php',
+    ]);
+
+return (new Config())
+    ->setRules([
+        '@PER-CS2.0' => true,
+        '@PHP84Migration' => true,
+        // Most rules below come from @Symfony and @PhpCsFixer, but there are a few differences in configuration,
+        // as well as some rules we just don't take at all because we have no official opinion on the style.
+        'backtick_to_shell_exec' => true,
+        'binary_operator_spaces' => ['default' => 'at_least_single_space'], // leaves existing alignments alone
+        'braces_position' => [
+            // these are all defaults, but it's good to spell them out here
+            'allow_single_line_anonymous_functions' => true,
+            'allow_single_line_empty_anonymous_classes' => true,
+            'anonymous_classes_opening_brace' => 'same_line',
+            'anonymous_functions_opening_brace' => 'same_line',
+            'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+            'control_structures_opening_brace' => 'same_line',
+            'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        ],
+        'class_attributes_separation' => ['elements' => ['method' => 'one']],
+        'class_definition' => ['single_line' => true],
+        'class_reference_name_casing' => true,
+        'declare_parentheses' => true,
+        'empty_loop_body' => ['style' => 'braces'],
+        'empty_loop_condition' => ['style' => 'while'],
+        'explicit_indirect_variable' => true,
+        'fully_qualified_strict_types' => ['import_symbols' => true],
+        'general_phpdoc_tag_rename' => ['replacements' => ['inheritDocs' => 'inheritDoc']],
+        'global_namespace_import' => ['import_classes' => true, 'import_constants' => true, 'import_functions' => false],
+        'include' => true,
+        'lambda_not_used_import' => true,
+        'magic_constant_casing' => true,
+        'magic_method_casing' => true,
+        'method_argument_space' => ['on_multiline' => 'ignore'],
+        'method_chaining_indentation' => true,
+        'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
+        'native_function_casing' => true,
+        'native_type_declaration_casing' => true,
+        'no_alias_language_construct_call' => true,
+        'no_alternative_syntax' => true,
+        'no_binary_string' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => [
+            'tokens' => [
+                'attribute', 'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra',
+                'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use',
+            ],
+        ],
+        'no_leading_namespace_whitespace' => true,
+        'no_mixed_echo_print' => ['use' => 'echo'],
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_around_offset' => true,
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_braces' => ['namespaces' => true],
+        'no_unneeded_control_parentheses' => [
+            'statements' => [
+                'break', 'clone', 'continue', 'echo_print', 'others', 'return', 'switch_case', 'yield', 'yield_from',
+            ],
+        ],
+        'no_unneeded_import_alias' => true,
+        'no_unused_imports' => true,
+        'no_useless_concat_operator' => ['juggle_simple_strings' => true],
+        'no_useless_nullsafe_operator' => true,
+        'no_useless_return' => true,
+        'nullable_type_declaration' => ['syntax' => 'question_mark'],
+        'object_operator_without_whitespace' => true,
+        'operator_linebreak' => ['only_booleans' => true],
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'ordered_types' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_align' => false, // align phpdoc yourself or don't, but we don't enforce it
+        'phpdoc_indent' => true,
+        'phpdoc_inline_tag_normalizer' => true,
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_order' => ['order' => ['param', 'return', 'throws']],
+        'phpdoc_order_by_value' => ['annotations' => ['covers']],
+        'phpdoc_return_self_reference' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'phpdoc_var_annotation_correct_order' => true,
+        'phpdoc_var_without_name' => true,
+        'protected_to_private' => true,
+        'self_static_accessor' => true,
+        'single_class_element_per_statement' => true,
+        'single_import_per_statement' => true,
+        'single_quote' => false, // we have no opinion on single quote use
+        'single_space_around_construct' => true,
+        'space_after_semicolon' => ['remove_in_empty_for_expressions' => true],
+        'standardize_not_equals' => true,
+        'string_implicit_backslashes' => true,
+        'switch_continue_to_break' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true,
+            'elements' => ['array_destructuring', 'arrays', 'match', 'parameters'],
+        ],
+        'trim_array_spaces' => true,
+        'type_declaration_spaces' => true,
+        'types_spaces' => ['space' => 'none'],
+        'unary_operator_spaces' => true,
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => false,  // official opinion on yoda style we do not have
+    ])
+    ->setFinder($finder)
+    ->setCacheFile(__DIR__ . '/.cache/.php_cs.cache')
+    ->setParallelConfig(ParallelConfigFactory::detect());

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,9 +8,8 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 $finder = (new Finder())
     ->in(__DIR__)
     ->exclude([
+        'var',
         'vendor',
-        'storage',
-        'bootstrap',
     ])
     ->notPath([
         '_ide_helper.php',

--- a/composer.json
+++ b/composer.json
@@ -70,9 +70,12 @@
     "scripts": {
         "phpstan": "phpstan --verbose --memory-limit=2G",
         "phpunit": "phpunit",
+        "php-cs-fixer": "php-cs-fixer",
         "test": "@phpunit",
         "test:unit": "@phpunit --testsuite=Unit",
         "test:functional": "@phpunit --testsuite=functional",
+        "style:check": "@php-cs-fixer check",
+        "style:fix": "@php-cs-fixer fix",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "thecodingmachine/safe": ">=2.5"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.65",
         "phpstan/phpstan": ">=1.12.12",
         "phpunit/phpunit": ">=11.4.4",
         "rector/rector": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c163ba055e5b80c5b5c1ffb55b51ea92",
+    "content-hash": "eb8540c63a4f68c0357bfac4543f7838",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5988,6 +5988,507 @@
     ],
     "packages-dev": [
         {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-19T14:15:21+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/8520451a140d3f46ac33042715115e290cf5785f",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-06T10:04:20+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "79d4f3e77b250a7d8043d76c6af8f0695e8a469f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/79d4f3e77b250a7d8043d76c6af8f0695e8a469f",
+                "reference": "79d4f3e77b250a7d8043d76c6af8f0695e8a469f",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.0",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.3",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.2",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.5",
+                "react/event-loop": "^1.0",
+                "react/promise": "^2.0 || ^3.0",
+                "react/socket": "^1.0",
+                "react/stream": "^1.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+                "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+                "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",
+                "symfony/polyfill-mbstring": "^1.28",
+                "symfony/polyfill-php80": "^1.28",
+                "symfony/polyfill-php81": "^1.28",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0",
+                "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.4",
+                "infection/infection": "^0.29.8",
+                "justinrainbow/json-schema": "^5.3 || ^6.0",
+                "keradus/cli-executor": "^2.1",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.7",
+                "php-cs-fixer/accessible-object": "^1.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.5",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.5",
+                "phpunit/phpunit": "^9.6.21 || ^10.5.38 || ^11.4.3",
+                "symfony/var-dumper": "^5.4.47 || ^6.4.15 || ^7.1.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.13 || ^7.1.6"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Fixer/Internal/*"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.65.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-25T00:39:24+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.12.1",
             "source": {
@@ -6703,6 +7204,536 @@
                 }
             ],
             "time": "2024-11-27T10:44:52+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "e71eb1aa55f057c7a4a0d08d06b0b0a484bead43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/e71eb1aa55f057c7a4a0d08d06b0b0a484bead43",
+                "reference": "e71eb1aa55f057c7a4a0d08d06b0b0a484bead43",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
+                "react/socket": "^1.8",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/WyriHaximus",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-16T13:41:56+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-13T14:18:03+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-11-13T13:48:05+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.10.39 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-05-24T10:39:05+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-07-26T10:38:09+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "rector/rector",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,10 +1,17 @@
 <?php
 
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
+use League\FlysystemBundle\FlysystemBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MakerBundle\MakerBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
+
 return [
-    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
-    League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
-    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
-    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
-    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+    FrameworkBundle::class => ['all' => true],
+    FlysystemBundle::class => ['all' => true],
+    DoctrineBundle::class => ['all' => true],
+    MonologBundle::class => ['all' => true],
+    MakerBundle::class => ['dev' => true],
+    DoctrineMigrationsBundle::class => ['all' => true],
 ];

--- a/config/preload.php
+++ b/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
-if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+if (file_exists(dirname(__DIR__) . '/var/cache/prod/App_KernelProdContainer.preload.php')) {
+    require dirname(__DIR__) . '/var/cache/prod/App_KernelProdContainer.preload.php';
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
+         cacheDirectory=".cache"
          executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"

--- a/public/index.php
+++ b/public/index.php
@@ -2,7 +2,7 @@
 
 use App\Kernel;
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 return function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);

--- a/src/Commands/SandboxCommand.php
+++ b/src/Commands/SandboxCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Commands;
 
-use App\Commands\AbstractBaseCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Commands/Sync/Download/AbstractDownloadCommand.php
+++ b/src/Commands/Sync/Download/AbstractDownloadCommand.php
@@ -71,7 +71,6 @@ abstract class AbstractDownloadCommand extends AbstractBaseCommand
         return Command::SUCCESS;
     }
 
-
     /**
      * @param array<string, string[]> $pending Array with slugs as keys and versions as values.
      * @return Generator<array{string, string}> yields [$slug, $version]
@@ -84,7 +83,7 @@ abstract class AbstractDownloadCommand extends AbstractBaseCommand
             // $this->log->debug("version count for $slug: $vcount", ['slug' => $slug, 'versions' => $versions]);
             foreach ($versions as $version) {
                 [$version, $message] = VersionUtil::cleanVersion($version);
-                if (! $version) {
+                if (!$version) {
                     $this->log->notice("Skipping $slug: $message");
                     continue;
                 }

--- a/src/Commands/Sync/Download/DownloadPluginsSingleCommand.php
+++ b/src/Commands/Sync/Download/DownloadPluginsSingleCommand.php
@@ -36,7 +36,7 @@ class DownloadPluginsSingleCommand extends AbstractBaseCommand
         $force   = $input->getOption('force');
 
         [$version, $message] = VersionUtil::cleanVersion($version);
-        if (! $version) {
+        if (!$version) {
             $this->log->error($message);
             return Command::FAILURE;
         }

--- a/src/Commands/Sync/Download/DownloadThemesSingleCommand.php
+++ b/src/Commands/Sync/Download/DownloadThemesSingleCommand.php
@@ -36,7 +36,7 @@ class DownloadThemesSingleCommand extends AbstractBaseCommand
         $force   = $input->getOption('force');
 
         [$version, $message] = VersionUtil::cleanVersion($version);
-        if (! $version) {
+        if (!$version) {
             $this->log->error($message);
             return Command::FAILURE;
         }

--- a/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
+++ b/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
@@ -108,7 +108,6 @@ abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
     protected function generateRequests(array $slugs): Generator
     {
         foreach ($slugs as $slug) {
-
             yield $this->makeRequest((string) $slug);
         }
     }
@@ -132,7 +131,7 @@ abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
             return;
         }
 
-        if (! empty($metadata['versions'])) {
+        if (!empty($metadata['versions'])) {
             $this->log->info("$slug ... [" . count($metadata['versions']) . ' versions]');
         } elseif (isset($metadata['version'])) {
             $this->log->info("$slug ... [1 version]");
@@ -147,7 +146,7 @@ abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
 
     protected function onError(Exception $exception): void
     {
-        if (! $exception instanceof RequestException) {
+        if (!$exception instanceof RequestException) {
             $this->log->error($exception->getMessage());
             return;
         }

--- a/src/Entity/SyncAsset.php
+++ b/src/Entity/SyncAsset.php
@@ -1,9 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace App\Entity;
 
 use App\Repository\SyncAssetRepository;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Types\UuidType;
@@ -17,7 +19,7 @@ use Symfony\Component\Uid\Uuid;
 class SyncAsset
 {
     #[ORM\Column(nullable: true)]
-    public ?\DateTimeImmutable $processed = null;  // mutable!
+    public ?DateTimeImmutable $processed = null;  // mutable!
 
     /**
      * @param array<string, mixed>|null $metadata
@@ -40,10 +42,9 @@ class SyncAsset
         public readonly string $url,
 
         #[ORM\Column]
-        public readonly \DateTimeImmutable $created,
+        public readonly DateTimeImmutable $created,
 
         #[ORM\Column(nullable: true)]
         public readonly ?array $metadata = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/Entity/SyncResource.php
+++ b/src/Entity/SyncResource.php
@@ -1,10 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace App\Entity;
 
 use App\Repository\SyncResourceRepository;
 use App\ResourceType;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -52,16 +54,15 @@ class SyncResource
 
         // when this record was synced
         #[ORM\Column]
-        public readonly \DateTimeImmutable $pulled,
+        public readonly DateTimeImmutable $pulled,
 
         // last updated date in metadata
         #[ORM\Column]
-        public readonly ?\DateTimeImmutable $updated,
+        public readonly ?DateTimeImmutable $updated,
 
         #[ORM\Column(nullable: true)]
-        public readonly ?array $metadata = null
-    )
-    {
+        public readonly ?array $metadata = null,
+    ) {
         $this->assets = new ArrayCollection();
     }
 

--- a/src/Factories/GuzzleClientFactory.php
+++ b/src/Factories/GuzzleClientFactory.php
@@ -10,7 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-
+use RuntimeException;
 
 class GuzzleClientFactory
 {
@@ -20,8 +20,7 @@ class GuzzleClientFactory
         $maxRetries = 10;
         $handler = HandlerStack::create();
         $retryMiddleware = Middleware::retry(
-            function (int $retries, RequestInterface $request, ?ResponseInterface $response, ?\RuntimeException $e)
-            use ($maxRetries) {
+            function (int $retries, RequestInterface $request, ?ResponseInterface $response, ?RuntimeException $e) use ($maxRetries) {
                 // Limit the number of retries to maxRetries
                 if ($retries >= $maxRetries) {
                     return false;
@@ -49,4 +48,3 @@ class GuzzleClientFactory
         return new GuzzleClient(['handler' => $handler, 'timeout' => 60, 'connect_timeout' => 2]);
     }
 }
-

--- a/src/Integrations/Wordpress/AbstractWordpressApiRequest.php
+++ b/src/Integrations/Wordpress/AbstractWordpressApiRequest.php
@@ -9,9 +9,7 @@ use Saloon\Http\Request;
 
 abstract class AbstractWordpressApiRequest extends Request
 {
-    public function __construct(public readonly string $slug)
-    {
-    }
+    public function __construct(public readonly string $slug) {}
 
     protected Method $method = Method::GET;
 }

--- a/src/Integrations/Wordpress/DownloadRequest.php
+++ b/src/Integrations/Wordpress/DownloadRequest.php
@@ -13,9 +13,8 @@ class DownloadRequest extends Request
         public readonly string $remotePath,
         public readonly string $localPath,
         public readonly string $slug,
-        public readonly string $version
-    ) {
-    }
+        public readonly string $version,
+    ) {}
 
     public function resolveEndpoint(): string
     {

--- a/src/Repository/SyncAssetRepository.php
+++ b/src/Repository/SyncAssetRepository.php
@@ -16,28 +16,28 @@ class SyncAssetRepository extends ServiceEntityRepository
         parent::__construct($registry, SyncAsset::class);
     }
 
-//    /**
-//     * @return SyncAsset[] Returns an array of SyncAsset objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('s')
-//            ->andWhere('s.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('s.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
+    //    /**
+    //     * @return SyncAsset[] Returns an array of SyncAsset objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('s')
+    //            ->andWhere('s.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('s.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
 
-//    public function findOneBySomeField($value): ?SyncAsset
-//    {
-//        return $this->createQueryBuilder('s')
-//            ->andWhere('s.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
+    //    public function findOneBySomeField($value): ?SyncAsset
+    //    {
+    //        return $this->createQueryBuilder('s')
+    //            ->andWhere('s.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
 }

--- a/src/Services/Download/AbstractDownloadService.php
+++ b/src/Services/Download/AbstractDownloadService.php
@@ -10,7 +10,6 @@ use App\Services\Metadata\MetadataServiceInterface;
 use App\Utilities\ArrayUtil;
 use Exception;
 use Generator;
-use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Saloon\Exceptions\Request\RequestException;
@@ -25,8 +24,7 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
         protected readonly WordpressDownloadConnector $connector,
         protected readonly FilesystemOperator $filesystem,
         protected readonly LoggerInterface $log,
-    ) {
-    }
+    ) {}
 
     abstract protected function getCategory(): string;
 
@@ -64,7 +62,7 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
         $this->meta->markProcessed($slug, $version);
 
         $contents = $response->getBody()->getContents();
-        if (! $contents) {
+        if (!$contents) {
             $this->log->warning("Empty response", compact('remotePath', 'localPath'));
             return;
         }
@@ -98,7 +96,7 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
 
         foreach ($slugsAndVersions as [$slug, $version]) {
             $url = $this->meta->getDownloadUrl($slug, $version);
-            if (! $url) {
+            if (!$url) {
                 $this->log->warning("No download URL", compact('slug', 'version'));
             }
 

--- a/src/Services/Download/PluginDownloadService.php
+++ b/src/Services/Download/PluginDownloadService.php
@@ -6,7 +6,6 @@ namespace App\Services\Download;
 
 use App\Integrations\Wordpress\WordpressDownloadConnector;
 use App\Services\Metadata\PluginMetadataService;
-use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;

--- a/src/Services/Download/ThemeDownloadService.php
+++ b/src/Services/Download/ThemeDownloadService.php
@@ -6,7 +6,6 @@ namespace App\Services\Download;
 
 use App\Integrations\Wordpress\WordpressDownloadConnector;
 use App\Services\Metadata\ThemeMetadataService;
-use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;

--- a/src/Services/Interfaces/DatabaseCacheService.php
+++ b/src/Services/Interfaces/DatabaseCacheService.php
@@ -14,9 +14,7 @@ class DatabaseCacheService implements CacheServiceInterface
 {
     private string $table = 'cache';
 
-    public function __construct(private Connection $connection)
-    {
-    }
+    public function __construct(private Connection $connection) {}
 
     public function remember(string $key, int $ttl, Closure $callback): mixed
     {

--- a/src/Services/Interfaces/RevisionMetadataServiceInterface.php
+++ b/src/Services/Interfaces/RevisionMetadataServiceInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
- namespace App\Services\Interfaces;
+namespace App\Services\Interfaces;
 
 interface RevisionMetadataServiceInterface
 {

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -8,15 +8,14 @@ use App\Services\Interfaces\RevisionMetadataServiceInterface;
 use App\Services\Interfaces\SubversionServiceInterface;
 use App\Services\Metadata\MetadataServiceInterface;
 
-readonly abstract class AbstractListService implements ListServiceInterface
+abstract readonly class AbstractListService implements ListServiceInterface
 {
     public function __construct(
         protected SubversionServiceInterface $svn,
         protected MetadataServiceInterface $meta,
         protected RevisionMetadataServiceInterface $revisions,
         protected string $category,
-    ) {
-    }
+    ) {}
 
     /**
      * @param string[] $filter
@@ -74,7 +73,7 @@ readonly abstract class AbstractListService implements ListServiceInterface
      */
     protected function filter(array $items, ?array $filter, ?int $min_age): array
     {
-        if (! $filter && ! $min_age) {
+        if (!$filter && !$min_age) {
             return $items;
         }
 
@@ -116,7 +115,7 @@ readonly abstract class AbstractListService implements ListServiceInterface
             $slug   = (string) $slug;
             $status = $this->meta->getStatus($slug);
             // Is this the first time we've seen the slug?
-            if (! $status) {
+            if (!$status) {
                 $update[$slug] = [];
             }
             if (in_array($slug, $requested, true)) {

--- a/src/Services/List/PluginListService.php
+++ b/src/Services/List/PluginListService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\List;
 
 use App\Services\Interfaces\SubversionServiceInterface;
-use App\Services\List\AbstractListService;
 use App\Services\Metadata\PluginMetadataService;
 use App\Services\RevisionMetadataService;
 

--- a/src/Services/List/ThemeListService.php
+++ b/src/Services/List/ThemeListService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Services\List;
 
-use App\Services\List\AbstractListService;
 use App\Services\Metadata\ThemeMetadataService;
 use App\Services\RevisionMetadataService;
 use App\Services\SubversionService;

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Services\Metadata;
 
 use App\ResourceType;
-use App\Services\Metadata\MetadataServiceInterface;
-use DateTimeImmutable;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Generator;
@@ -23,8 +21,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
         protected LoggerInterface $log,
         protected ResourceType $resource,
         protected string $origin = 'wp_org',
-    ) {
-    }
+    ) {}
 
     /** @param array<string, mixed> $metadata */
     public function save(array $metadata): void
@@ -35,7 +32,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             'open'  => $this->saveOpen(...),
             default => $this->saveError(...),
         };
-        $this->connection->transactional(fn () => $method($metadata));
+        $this->connection->transactional(fn() => $method($metadata));
     }
 
     /** @param array<string, mixed> $metadata */
@@ -113,14 +110,14 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
     public function getDownloadUrl(string $slug, string $version): ?string
     {
         $sql    = <<<'SQL'
-            SELECT url
-            FROM sync_assets 
-                JOIN sync ON sync.id = sync_assets.sync_id 
-            WHERE sync.slug = :slug 
-              AND sync.type = :type
-              AND sync.origin = :origin
-              AND sync_assets.version = :version
-        SQL;
+                SELECT url
+                FROM sync_assets 
+                    JOIN sync ON sync.id = sync_assets.sync_id 
+                WHERE sync.slug = :slug 
+                  AND sync.type = :type
+                  AND sync.origin = :origin
+                  AND sync_assets.version = :version
+            SQL;
         $result = $this->connection->fetchAssociative($sql, ['slug' => $slug, 'version' => $version, ...$this->stdArgs()]);
         return $result['url'] ?? null;
     }
@@ -129,14 +126,14 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
     public function getOpenVersions(string $revDate = '1900-01-01'): array
     {
         $sql    = <<<SQL
-            SELECT slug, sync_assets.version 
-            FROM sync_assets
-                JOIN sync ON sync.id = sync_assets.sync_id 
-            WHERE status = 'open'
-              AND pulled >= :revDate
-              AND sync.type = :type
-              AND sync.origin = :origin
-        SQL;
+                SELECT slug, sync_assets.version 
+                FROM sync_assets
+                    JOIN sync ON sync.id = sync_assets.sync_id 
+                WHERE status = 'open'
+                  AND pulled >= :revDate
+                  AND sync.type = :type
+                  AND sync.origin = :origin
+            SQL;
         $result = $this->connection->fetchAllAssociative($sql, ['revDate' => $revDate, ...$this->stdArgs()]);
 
         $out = [];

--- a/src/Services/Metadata/PluginMetadataService.php
+++ b/src/Services/Metadata/PluginMetadataService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\Metadata;
 
 use App\ResourceType;
-use App\Services\Metadata\AbstractMetadataService;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 

--- a/src/Services/Metadata/ThemeMetadataService.php
+++ b/src/Services/Metadata/ThemeMetadataService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\Metadata;
 
 use App\ResourceType;
-use App\Services\Metadata\AbstractMetadataService;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 

--- a/src/Services/RevisionMetadataService.php
+++ b/src/Services/RevisionMetadataService.php
@@ -28,7 +28,7 @@ class RevisionMetadataService implements RevisionMetadataServiceInterface
 
     public function preserveRevision(string $action): string
     {
-        if (! isset($this->currentRevision[$action])) {
+        if (!isset($this->currentRevision[$action])) {
             throw new RuntimeException('You did not specify a revision for action ' . $action);
         }
         $revision = $this->currentRevision[$action]['revision'];

--- a/src/Services/SubversionService.php
+++ b/src/Services/SubversionService.php
@@ -12,9 +12,7 @@ use Symfony\Component\Process\Process;
 
 class SubversionService implements SubversionServiceInterface
 {
-    public function __construct(private readonly GuzzleClient $guzzle)
-    {
-    }
+    public function __construct(private readonly GuzzleClient $guzzle) {}
 
     /** @return array{slugs: array<string, string[]>, revision: int} */
     public function getUpdatedSlugs(string $type, int $prevRevision, int $lastRevision): array
@@ -29,7 +27,7 @@ class SubversionService implements SubversionServiceInterface
         $process = new Process($command);
         $process->run();
 
-        if (! $process->isSuccessful()) {
+        if (!$process->isSuccessful()) {
             throw new RuntimeException("Unable to get list of $type to update: {$process->getErrorOutput()}");
         }
 

--- a/src/Utilities/FileUtil.php
+++ b/src/Utilities/FileUtil.php
@@ -28,7 +28,7 @@ abstract class FileUtil
     public static function readJson(string $path): array  // @phpstan-ignore missingType.iterableValue
     {
         $content = json_decode(static::read($path), true, 512, JSON_THROW_ON_ERROR);
-        if (! is_array($content)) {
+        if (!is_array($content)) {
             throw new RuntimeException("Cannot decode json file {$path} -- content is not an object or array");
         }
         return $content;

--- a/src/Utilities/RegexUtil.php
+++ b/src/Utilities/RegexUtil.php
@@ -75,7 +75,7 @@ class RegexUtil
         string|array $replacement,
         string|array $subject,
         int $limit = -1,
-        ?int &$count = null
+        ?int &$count = null,
     ): string|array {
         return preg_replace($pattern, $replacement, $subject, $limit, $count);
     }

--- a/src/Utilities/VersionUtil.php
+++ b/src/Utilities/VersionUtil.php
@@ -50,7 +50,7 @@ abstract class VersionUtil
     public static function cleanVersion(string $version): array
     {
         // $version = trim($version); // XXX bad idea, the data needs to be cleaned at the source.
-        if (! \Safe\preg_match('/^[-A-Za-z0-9_.]+$/', $version)) {
+        if (!\Safe\preg_match('/^[-A-Za-z0-9_.]+$/', $version)) {
             $encoded = urlencode($version);
             return [null, "Invalid version [urlencoded version: $encoded]"];
         }

--- a/symfony.lock
+++ b/symfony.lock
@@ -26,6 +26,18 @@
             "migrations/.gitignore"
         ]
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "3.65",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "be2103eb4a20942e28a6dd87736669b757132435"
+        },
+        "files": [
+            ".php-cs-fixer.dist.php"
+        ]
+    },
     "league/flysystem-bundle": {
         "version": "3.3",
         "recipe": {

--- a/tests/Unit/Utilities/WP/FileHeaderParserTest.php
+++ b/tests/Unit/Utilities/WP/FileHeaderParserTest.php
@@ -12,18 +12,18 @@ class FileHeaderParserTest extends TestCase
     public function testReadPluginHeader(): void
     {
         $header = <<<HEADER
-        /*
-         * Plugin Name: Plugin Directory
-         * Plugin URI: https://wordpress.org/plugins/
-         * Description: Transforms a WordPress site in The Official Plugin Directory.
-         * Version: 3.0
-         * Author: the WordPress team
-         * Author URI: https://wordpress.org/
-         * Text Domain: wporg-plugins
-         * License: GPLv2
-         * License URI: https://opensource.org/licenses/gpl-2.0.php
-        */
-        HEADER;
+            /*
+             * Plugin Name: Plugin Directory
+             * Plugin URI: https://wordpress.org/plugins/
+             * Description: Transforms a WordPress site in The Official Plugin Directory.
+             * Version: 3.0
+             * Author: the WordPress team
+             * Author URI: https://wordpress.org/
+             * Text Domain: wporg-plugins
+             * License: GPLv2
+             * License URI: https://opensource.org/licenses/gpl-2.0.php
+            */
+            HEADER;
 
         $headers = FileHeaderParser::readPluginHeader($header);
 
@@ -48,22 +48,22 @@ class FileHeaderParserTest extends TestCase
     public function testThemeHeader(): void
     {
         $header = <<<HEADER
-        /*
-        Theme Name: Twenty Twenty-Five
-        Theme URI: https://wp.org/themes/twentytwentyfive/
-        Author: the WordPress team
-        Author URI: https://wp.org
-        Description: Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible design options, supported by a variety of patterns for different page types, such as services and landing pages, making it ideal for building personal blogs, professional portfolios, online magazines, or business websites. Its templates cater to various blog styles, from text-focused to image-heavy layouts. Additionally, it supports international typography and diverse color palettes, ensuring accessibility and customization for users worldwide.
-        Requires at least: 6.7
-        Tested up to: 6.7
-        Requires PHP: 7.2.24
-        Version: 1.0
-        License: GNU General Public License v2 or later
-        License URI: http://www.gnu.org/licenses/gpl-2.0.html
-        Text Domain: twentytwentyfive
-        Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, block-styles, style-variations, accessibility-ready, blog, portfolio, news
-        */
-        HEADER;
+            /*
+            Theme Name: Twenty Twenty-Five
+            Theme URI: https://wp.org/themes/twentytwentyfive/
+            Author: the WordPress team
+            Author URI: https://wp.org
+            Description: Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible design options, supported by a variety of patterns for different page types, such as services and landing pages, making it ideal for building personal blogs, professional portfolios, online magazines, or business websites. Its templates cater to various blog styles, from text-focused to image-heavy layouts. Additionally, it supports international typography and diverse color palettes, ensuring accessibility and customization for users worldwide.
+            Requires at least: 6.7
+            Tested up to: 6.7
+            Requires PHP: 7.2.24
+            Version: 1.0
+            License: GNU General Public License v2 or later
+            License URI: http://www.gnu.org/licenses/gpl-2.0.html
+            Text Domain: twentytwentyfive
+            Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, block-styles, style-variations, accessibility-ready, blog, portfolio, news
+            */
+            HEADER;
 
         $headers = FileHeaderParser::readThemeHeader($header);
 


### PR DESCRIPTION
# Pull Request

## What changed?

This uses php-cs-fixer as our style checker and formatter, using the same custom ruleset as AspireCloud.

## Why did it change?

Easier to maintain one style linter with a consistent style, and php-cs-fixer has more and better checkers than phpcs.

## Did you fix any specific issues?

nyet

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

