### PR TITLE
fix: truncate sync_assets version to 32 and url to 4096

### DIFF
--- a/src/Services/Download/AbstractDownloadService.php
+++ b/src/Services/Download/AbstractDownloadService.php
@@ -70,8 +70,13 @@ abstract class AbstractDownloadService implements DownloadServiceInterface
         $this->filesystem->write($localPath, $contents);
     }
 
-    protected function onError(RequestException $exception): void
+    protected function onError(Exception $exception): void
     {
+        if (!($exception instanceof RequestException)) {
+            $this->log->error("ERROR: " . $exception->getMessage());
+            return;
+        }
+
         $saloonResponse = $exception->getResponse();
         $response       = $saloonResponse->getPsrResponse();
         $request        = $saloonResponse->getRequest();

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -116,7 +116,7 @@ abstract class AbstractListService implements ListServiceInterface
         foreach ($this->em->getConnection()->fetchAllAssociative($sql) as $revision) {
             $this->revisionData[$revision['action']] = [
                 'revision' => $revision['revision'],
-                'added'    => $revision['created'],
+                'added'    => $revision['added'],
             ];
         }
     }

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -37,11 +37,9 @@ abstract class AbstractListService implements ListServiceInterface
     /** @return array<string|int, array{}> */
     public function getUpdatedItems(): array
     {
-        $revision = $this->getRevisionDate();
-        if ($revision) {
-            $revision = \Safe\date('Y-m-d', \Safe\strtotime($revision));
-        }
-        return $this->meta->getOpenVersions($revision);
+        // HACK: return everything until meta and download versions of ListService get different names
+        return $this->meta->getOpenVersions(-1);    // FIXME: make getRevisionTime() work again
+        // return $this->meta->getOpenVersions($this->getRevisionTime());
     }
 
     public function preserveRevision(): string
@@ -101,9 +99,9 @@ abstract class AbstractListService implements ListServiceInterface
         return $this->revisionData[$this->name]['revision'] ?? null;
     }
 
-    public function getRevisionDate(): ?string
+    public function getRevisionTime(): int
     {
-        return $this->revisionData[$this->name]['added'] ?? null;
+        return $this->revisionData[$this->name]['added'] ?? 1;
     }
 
     private function loadLatestRevisions(): void

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -63,8 +63,8 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             $this->connection()->insert('sync_assets', [
                 'id'      => Uuid::uuid7()->toString(),
                 'sync_id' => $id,
-                'version' => $version,
-                'url'     => $url,
+                'version' => mb_substr((string) $version, 0, 32),
+                'url'     => mb_substr($url, 0, 4096),
                 'created' => time(),
             ]);
         }

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -120,9 +120,8 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
     }
 
     /** @return array<string, string[]> [slug => [versions]] */
-    public function getOpenVersions(string $revDate = '1900-01-01'): array
+    public function getOpenVersions(int $timestamp = 1): array
     {
-        $stamp  = strtotime($revDate);
         $sql = <<<SQL
                 SELECT slug, sync_assets.version 
                 FROM sync_assets
@@ -132,7 +131,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
                   AND sync.type = :type
                   AND sync.origin = :origin
             SQL;
-        $result = $this->connection()->fetchAllAssociative($sql, ['stamp' => $stamp, ...$this->stdArgs()]);
+        $result = $this->connection()->fetchAllAssociative($sql, ['stamp' => $timestamp, ...$this->stdArgs()]);
 
         $out = [];
         foreach ($result as $row) {

--- a/src/Services/Metadata/MetadataServiceInterface.php
+++ b/src/Services/Metadata/MetadataServiceInterface.php
@@ -22,7 +22,7 @@ interface MetadataServiceInterface
     public function save(array $metadata): void;
 
     /** @return array<string|int, string[]> */
-    public function getOpenVersions(string $revDate = '1900-01-01'): array;
+    public function getOpenVersions(int $timestamp = 1): array;
 
     public function markProcessed(string $slug, string $version): void;
 

--- a/tests/Stubs/MetadataServiceStub.php
+++ b/tests/Stubs/MetadataServiceStub.php
@@ -34,7 +34,7 @@ class MetadataServiceStub implements MetadataServiceInterface
         return 'open';
     }
 
-    public function getOpenVersions(string $revDate = '1900-01-01'): array
+    public function getOpenVersions(?int $timestamp = 1): array
     {
         return [];
     }


### PR DESCRIPTION
# Pull Request

## What changed?

* Truncated the "version" column in sync_assets to 32.  That I even have to do this ... 🙄 

* Also wrapped the guzzle response/error handlers in try/catch so they won't take down the whole sync process.

## Why did it change?

To not crash.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

