### PR TITLE
fix revision tracking

### DIFF
--- a/src/Commands/Sync/Download/AbstractDownloadCommand.php
+++ b/src/Commands/Sync/Download/AbstractDownloadCommand.php
@@ -38,6 +38,7 @@ abstract class AbstractDownloadCommand extends AbstractBaseCommand
             ->addOption($category, null, InputOption::VALUE_OPTIONAL, "List of $category to request")
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force download even if file exists')
             ->addOption('download-all', null, InputOption::VALUE_NONE, "Download all $category");
+        $this->listService->setName($this->getName());
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
+++ b/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
@@ -60,6 +60,7 @@ abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
                 InputOption::VALUE_REQUIRED,
                 "List of $category (separated by commas) to explicitly update"
             );
+        $this->listService->setName($this->getName());
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -41,9 +41,7 @@ abstract class AbstractListService implements ListServiceInterface
     /** @return array<string|int, array{}> */
     public function getUpdatedItems(): array
     {
-        // HACK: return everything until meta and download versions of ListService get different names
-        return $this->meta->getOpenVersions(-1);    // FIXME: make getRevisionTime() work again
-        // return $this->meta->getOpenVersions($this->getRevisionTime());
+        return $this->meta->getOpenVersions($this->getRevisionTime());
     }
 
     public function preserveRevision(): string

--- a/src/Services/List/AbstractListService.php
+++ b/src/Services/List/AbstractListService.php
@@ -21,11 +21,15 @@ abstract class AbstractListService implements ListServiceInterface
         protected ResourceType $type,
         protected string $origin = 'wp_org',
     ) {
-        $this->name = "list-{$type->plural()}@$origin";
         $this->loadLatestRevisions();
     }
 
     //region Public API
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
 
     /** @return array<string|int, string[]> */
     public function getItems(): array

--- a/src/Services/List/ListServiceInterface.php
+++ b/src/Services/List/ListServiceInterface.php
@@ -6,6 +6,8 @@ namespace App\Services\List;
 
 interface ListServiceInterface
 {
+    public function setName(string $name): void;
+
     /** @return array<string, string[]> */
     public function getItems(): array;
 


### PR DESCRIPTION
# Pull Request

## What changed?

commands now call `$this->listService->setName($this->getName())` to record revisions in the format they did before.

## Why did it change?

bugfix

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

