### PR TITLE
CLI command to upload plugins/themes to AspireCloud

### DIFF
--- a/.env
+++ b/.env
@@ -16,12 +16,6 @@
 
 ########## AspireSync Config
 
-# TODO: ditch log config in here and use symfony config
-# Log level may be one of: emergency | alert | critical | error | warning | notice | info | debug
-# LOG_FILE=/tmp/aspiresync.log
-#LOG_FILE=/dev/null
-#LOG_LEVEL=debug
-
 DOWNLOADS_FILESYSTEM=local
 #DOWNLOADS_DIR=/path/to/downloads/dir
 
@@ -31,6 +25,10 @@ DOWNLOADS_FILESYSTEM=local
 #S3_SECRET=
 #S3_REGION=
 #S3_ENDPOINT=
+
+# in .env.local, use http://api.aspiredev.org/admin/api   (note http and not https)
+ASPIRECLOUD_ADMIN_API_URL=https://api.aspirecloud.io/admin/api
+ASPIRECLOUD_ADMIN_API_KEY=
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AspireSync is designed to enumerate and download the plugins and themes stored i
 
 * Download themes and plugins from the WordPress .org repository to the local filesystem or S3 storage.
 * Stores metadata and other information about every version of every plugin in sqlite.
-* Can export metadata as newline-delimited json for consumption by [AspireCloud](https://github.com/aspiresync/AspireCloud). 
+* Can export metadata as newline-delimited json for consumption by [AspireCloud](https://github.com/aspiresync/AspireCloud).
 * Can download all versions of plugins and themes, or just the latest version.
 * Handles closed and not found plugins/themes, preventing further download attempts for them.
 * Incremental updates, syncing only those items that have updated in subversion since the last sync.
@@ -34,3 +34,16 @@ You can configure the following environment variables to determine where uploads
 | S3_ENDPOINT          | The S3 API endpoint, only required if using S3 storage from a provider other than AWS                                    |
 | S3_KEY               | The AWS access_key_id for S3.  Optional if host/container roles are in effect.                                           |
 | S3_SECRET            | The companion secret to the `S3_KEY`;   Optional if host/container roles are in effect.                                  |
+
+### AspireCloud Integration
+
+To upload metadata to AspireCloud, use the
+`meta/bin/push-to-aspirecloud` script, which requires two environment variables:
+*
+*NOTE:
+** these variables must be set in your actual environment: putting them only in a .env file will not work!
+
+| Env Variable              | Description                                                                                            |
+|---------------------------|--------------------------------------------------------------------------------------------------------|
+| ASPIRECLOUD_ADMIN_API_URL | Base URL of AC admin API, e.g. `http://aspiredev.org/admin/api/v1`.  Do not include a trailing slash.  |
+| ASPIRECLOUD_ADMIN_API_KEY | API key generated in the AC instance.  Must belong to a user with RepoAdmin or SuperAdmin permissions. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
       context: .
       dockerfile: docker/webapp/Dockerfile
       target: dev
+    environment:
+      ASPIRECLOUD_ADMIN_API_URL: ${ASPIRECLOUD_ADMIN_API_URL}
+      ASPIRECLOUD_ADMIN_API_KEY: ${ASPIRECLOUD_ADMIN_API_KEY}
     ports:
       - ${LOCAL_HTTP_PORT:-8199}:80
     volumes:

--- a/meta/bin/prelude.bash
+++ b/meta/bin/prelude.bash
@@ -6,9 +6,6 @@ set -o errexit
 cd $(dirname $0)/../..
 base=$(pwd)
 
-[[ -f .env ]] && . .env
-[[ -f .env.local ]] && . .env.local
-
 function warn {
     echo "$@" >&2
 }

--- a/meta/bin/prelude.bash
+++ b/meta/bin/prelude.bash
@@ -6,6 +6,9 @@ set -o errexit
 cd $(dirname $0)/../..
 base=$(pwd)
 
+[[ -f .env ]] && . .env
+[[ -f .env.local ]] && . .env.local
+
 function warn {
     echo "$@" >&2
 }

--- a/meta/bin/push-to-aspirecloud
+++ b/meta/bin/push-to-aspirecloud
@@ -2,17 +2,42 @@
 
 . $(dirname $0)/prelude.bash
 
-type=$1
-[[ $type = 'plugins' ]] || [[ $type = 'themes' ]] || die "Usage: $0 plugins|themes"
+URL=${ASPIRECLOUD_ADMIN_API_URL:?variable not defined}
+KEY=${ASPIRECLOUD_ADMIN_API_KEY:?variable not defined}
 
-key=${ASPIRECLOUD_ADMIN_API_KEY:?variable not defined}
-url=${ASPIRECLOUD_ADMIN_API_URL:?variable not defined}
+CHUNK_SIZE=${CHUNK_SIZE:-50} # values > 100 are likely to run into POST size limits
 
-bin/console sync:meta:dump:$type | curl -XPOST \
-  -H "Authorization: Bearer $key" \
-  -H 'Content-Type: application/nljson' \
-  -H 'Accept: application/json' \
-  --data-binary @- \
-  $CURL_EXTRA_ARGS \
-  $url/v1/import
+function main() {
+  local type=$1
+  [[ $type = 'plugins' ]] || [[ $type = 'themes' ]] || die "Usage: $0 plugins|themes"
 
+  local buffer=$(mktemp)
+  trap 'rm -f "$buffer"' EXIT
+
+  local count=0
+
+  while IFS= read -r line || [[ -n $line ]]; do
+    echo "$line" >> $buffer
+    (( count += 1 ))
+    echo -e -n "\ruploading $count $type ... "
+    [[ $(wc -l < $buffer) -ge $CHUNK_SIZE ]] && upload $buffer
+  done < <(bin/console sync:meta:dump:$type)
+
+  upload $buffer
+
+  echo "done"
+}
+
+function upload() {
+  buffer=$1
+  [[ -s $buffer ]] && curl --silent -XPOST \
+    -H "Authorization: Bearer $KEY" \
+    -H 'Content-Type: application/nljson' \
+    -H 'Accept: application/json' \
+    --data-binary @"$buffer" \
+    $CURL_EXTRA_ARGS \
+    "$URL/v1/import" > /dev/null
+  cp /dev/null $buffer
+}
+
+main "$@"

--- a/meta/bin/push-to-aspirecloud
+++ b/meta/bin/push-to-aspirecloud
@@ -5,7 +5,7 @@
 URL=${ASPIRECLOUD_ADMIN_API_URL:?variable not defined}
 KEY=${ASPIRECLOUD_ADMIN_API_KEY:?variable not defined}
 
-CHUNK_SIZE=${CHUNK_SIZE:-50} # values > 100 are likely to run into POST size limits
+CHUNK_SIZE=${CHUNK_SIZE:-100} # values > 100 are likely to run into POST size limits
 
 CURL_ARGS=${CURL_ARGS:-'--compressed'}
 

--- a/meta/bin/push-to-aspirecloud
+++ b/meta/bin/push-to-aspirecloud
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+. $(dirname $0)/prelude.bash
+
+type=$1
+[[ $type = 'plugins' ]] || [[ $type = 'themes' ]] || die "Usage: $0 plugins|themes"
+
+
+key=${ASPIRECLOUD_ADMIN_API_KEY:?variable not defined}
+url=${ASPIRECLOUD_ADMIN_API_URL:?variable not defined}
+
+bin/console sync:meta:dump:$type | curl -XPOST \
+  -H "Authorization: Bearer $key" \
+  -H 'Content-Type: application/nljson' \
+  -H 'Accept: application/json' \
+  --data-binary @- \
+  $CURL_EXTRA_ARGS \
+  $url/v1/import
+

--- a/meta/bin/push-to-aspirecloud
+++ b/meta/bin/push-to-aspirecloud
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#
+# EXAMPLE: bin/console sync:meta:dump:plugins --after='-1 hour' | meta/bin/push-to-aspirecloud
+#
+
 . $(dirname $0)/prelude.bash
 
 URL=${ASPIRECLOUD_ADMIN_API_URL:?variable not defined}
@@ -10,9 +14,6 @@ CHUNK_SIZE=${CHUNK_SIZE:-100} # values > 100 are likely to run into POST size li
 CURL_ARGS=${CURL_ARGS:-'--compressed'}
 
 function main() {
-  local type=$1
-  [[ $type = 'plugins' ]] || [[ $type = 'themes' ]] || die "Usage: $0 plugins|themes"
-
   local buffer=$(mktemp)
   trap 'rm -f "$buffer"' EXIT
 
@@ -21,9 +22,9 @@ function main() {
   while IFS= read -r line || [[ -n $line ]]; do
     echo "$line" >> $buffer
     (( count += 1 ))
-    echo -e -n "\ruploading $count $type ... "
+    echo -e -n "\ruploading $count ... "
     [[ $(wc -l < $buffer) -ge $CHUNK_SIZE ]] && upload $buffer
-  done < <(bin/console sync:meta:dump:$type)
+  done
 
   upload $buffer
 

--- a/meta/bin/push-to-aspirecloud
+++ b/meta/bin/push-to-aspirecloud
@@ -7,6 +7,8 @@ KEY=${ASPIRECLOUD_ADMIN_API_KEY:?variable not defined}
 
 CHUNK_SIZE=${CHUNK_SIZE:-50} # values > 100 are likely to run into POST size limits
 
+CURL_ARGS=${CURL_ARGS:-'--compressed'}
+
 function main() {
   local type=$1
   [[ $type = 'plugins' ]] || [[ $type = 'themes' ]] || die "Usage: $0 plugins|themes"
@@ -35,7 +37,7 @@ function upload() {
     -H 'Content-Type: application/nljson' \
     -H 'Accept: application/json' \
     --data-binary @"$buffer" \
-    $CURL_EXTRA_ARGS \
+    $CURL_ARGS \
     "$URL/v1/import" > /dev/null
   cp /dev/null $buffer
 }

--- a/meta/bin/push-to-aspirecloud
+++ b/meta/bin/push-to-aspirecloud
@@ -5,7 +5,6 @@
 type=$1
 [[ $type = 'plugins' ]] || [[ $type = 'themes' ]] || die "Usage: $0 plugins|themes"
 
-
 key=${ASPIRECLOUD_ADMIN_API_KEY:?variable not defined}
 url=${ASPIRECLOUD_ADMIN_API_URL:?variable not defined}
 

--- a/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
+++ b/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function Safe\json_decode;
+use function Safe\json_decode;  
 
 abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
 {

--- a/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
+++ b/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function Safe\json_decode;  
+use function Safe\json_decode;
 
 abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
 {

--- a/src/Commands/Sync/Meta/MetaDumpPluginsCommand.php
+++ b/src/Commands/Sync/Meta/MetaDumpPluginsCommand.php
@@ -8,6 +8,7 @@ use App\Commands\AbstractBaseCommand;
 use App\Services\Metadata\PluginMetadataService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class MetaDumpPluginsCommand extends AbstractBaseCommand
@@ -21,14 +22,18 @@ class MetaDumpPluginsCommand extends AbstractBaseCommand
     protected function configure(): void
     {
         $this->setName('sync:meta:dump:plugins')
-            ->setDescription('Dumps metadata of all plugins in jsonl format');
+            ->setDescription('Dumps metadata of all plugins in jsonl format')
+            ->addOption('after', null, InputOption::VALUE_REQUIRED, 'Dump only plugins synced after this date');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->startTimer();
 
-        foreach ($this->meta->exportAllMetadata() as $json) {
+        $after = $input->getOption('after');
+        $timestamp = $after ? \Safe\strtotime($after) : 0;
+
+        foreach ($this->meta->exportAllMetadata($timestamp) as $json) {
             echo $json . PHP_EOL;
         }
 

--- a/src/Commands/Sync/Meta/MetaDumpThemesCommand.php
+++ b/src/Commands/Sync/Meta/MetaDumpThemesCommand.php
@@ -8,6 +8,7 @@ use App\Commands\AbstractBaseCommand;
 use App\Services\Metadata\ThemeMetadataService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class MetaDumpThemesCommand extends AbstractBaseCommand
@@ -21,14 +22,18 @@ class MetaDumpThemesCommand extends AbstractBaseCommand
     protected function configure(): void
     {
         $this->setName('sync:meta:dump:themes')
-            ->setDescription('Dumps metadata of all themes in jsonl format');
+            ->setDescription('Dumps metadata of all themes in jsonl format')
+            ->addOption('after', null, InputOption::VALUE_REQUIRED, 'Dump only plugins synced after this date');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->startTimer();
 
-        foreach ($this->meta->exportAllMetadata() as $json) {
+        $after = $input->getOption('after');
+        $timestamp = $after ? \Safe\strtotime($after) : 0;
+
+        foreach ($this->meta->exportAllMetadata($timestamp) as $json) {
             echo $json . PHP_EOL;
         }
 

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -156,10 +156,11 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
         $this->connection()->executeQuery($sql, ['stamp' => time(), 'slug' => $slug, 'version' => $version, ...$this->stdArgs()]);
     }
 
-    public function exportAllMetadata(): Generator
+    public function exportAllMetadata(int $after = 0): Generator
     {
-        $sql  = "select * from sync where status in ('open', 'closed') and type = :type and origin = :origin";
-        $rows = $this->connection()->executeQuery($sql, $this->stdArgs());
+        $query = $this->querySync()->select('*');
+        $after > 0 and $query->andWhere('pulled > :after')->setParameter('after', $after);
+        $rows = $query->executeQuery();
         while ($row = $rows->fetchAssociative()) {
             $metadata = json_decode($row['metadata'], true);
             unset($row['metadata']);

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -45,7 +45,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
     {
         $id = Uuid::uuid7()->toString();
         $slug = mb_substr($metadata['slug'], 0, 255);
-        $version = mb_substr((string)$metadata['version'], 0, 32);
+        $version = mb_substr((string) $metadata['version'], 0, 32);
 
         if (!$clobber && $this->slugAndVersionExists($slug, $version)) {
             $this->log->debug("Not updating unmodified {$this->resource->value}", compact('slug', 'version'));
@@ -70,7 +70,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             $this->connection()->insert('sync_assets', [
                 'id' => Uuid::uuid7()->toString(),
                 'sync_id' => $id,
-                'version' => mb_substr((string)$version, 0, 32),
+                'version' => mb_substr((string) $version, 0, 32),
                 'url' => mb_substr($url, 0, 4096),
                 'created' => time(),
             ]);
@@ -267,27 +267,27 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
     private function slugAndVersionExists(string $slug, string $version): bool
     {
         return $this
-                ->querySync()
-                ->select('1')
-                ->andWhere('slug = :slug')
-                ->andWhere('version = :version')
-                ->setParameter('slug', $slug)
-                ->setParameter('version', $version)
-                ->executeQuery()
-                ->fetchOne() !== false;
+            ->querySync()
+            ->select('1')
+            ->andWhere('slug = :slug')
+            ->andWhere('version = :version')
+            ->setParameter('slug', $slug)
+            ->setParameter('version', $version)
+            ->executeQuery()
+            ->fetchOne() !== false;
     }
 
     private function slugAndStatusExists(string $slug, string $status): bool
     {
         return $this
-                ->querySync()
-                ->select('1')
-                ->andWhere('slug = :slug')
-                ->andWhere('status = :status')
-                ->setParameter('slug', $slug)
-                ->setParameter('status', $status)
-                ->executeQuery()
-                ->fetchOne() !== false;
+            ->querySync()
+            ->select('1')
+            ->andWhere('slug = :slug')
+            ->andWhere('status = :status')
+            ->setParameter('slug', $slug)
+            ->setParameter('status', $status)
+            ->executeQuery()
+            ->fetchOne() !== false;
     }
 
     //endregion

--- a/src/Services/Metadata/MetadataServiceInterface.php
+++ b/src/Services/Metadata/MetadataServiceInterface.php
@@ -19,7 +19,7 @@ interface MetadataServiceInterface
     public function exportAllMetadata(): Generator;
 
     /** @param array<string, mixed> $metadata */
-    public function save(array $metadata): void;
+    public function save(array $metadata, bool $clobber = false): void;
 
     /** @return array<string|int, string[]> */
     public function getOpenVersions(int $timestamp = 1): array;

--- a/tests/Stubs/MetadataServiceStub.php
+++ b/tests/Stubs/MetadataServiceStub.php
@@ -24,7 +24,7 @@ class MetadataServiceStub implements MetadataServiceInterface
         yield from [];
     }
 
-    public function save(array $metadata): void
+    public function save(array $metadata, bool $clobber = false): void
     {
         // de nada
     }


### PR DESCRIPTION
# Pull Request

## What changed?

This PR adds the `meta/bin/push-to-aspirecloud` command, which reads the output of `sync:meta:dump` commands on stdin and pipes it into curl to hit the AC management API.

## Why did it change?

The AC management API is the practical way to work with the AC database, since loading from files or stdin requires low-level system access that doesn't translate well outside of local dev.

## Did you fix any specific issues?

This is a front end for aspirepress/AspireCloud#123

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

