### PR TITLE
new timestamp filtering options for sync:meta:fetch

### DIFF
--- a/migrations/Version20250119175506.php
+++ b/migrations/Version20250119175506.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250119175506 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add checked column to sync table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('alter table sync add checked int not null default 0');
+        $this->addSql('alter table sync alter column checked drop default');
+        $this->addSql('create index idx_checked on sync (checked)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sync DROP checked');
+    }
+}

--- a/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
+++ b/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
@@ -88,7 +88,7 @@ abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
         $this->startTimer();
 
         $this->clobber = (bool) $input->getOption('update-all');
-        $this->limit = (int)$input->getOption('limit');
+        $this->limit = (int) $input->getOption('limit');
 
         $pulledCutoff = (int) $input->getOption('skip-pulled-after');
         $checkedCutoff = (int) $input->getOption('skip-checked-after');

--- a/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
+++ b/src/Commands/Sync/Meta/AbstractMetaFetchCommand.php
@@ -88,7 +88,8 @@ abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
         $this->startTimer();
 
         $this->clobber = (bool) $input->getOption('update-all');
-        $this->limit = (int) $input->getOption('limit');
+        $limit = $input->getOption('limit');
+        $this->limit = ($limit === null) ? null : (int) $limit; // don't convert null to 0
 
         $pulledCutoff = (int) $input->getOption('skip-pulled-after');
         $checkedCutoff = (int) $input->getOption('skip-checked-after');
@@ -153,6 +154,7 @@ abstract class AbstractMetaFetchCommand extends AbstractBaseCommand
     {
         foreach ($slugs as $slug) {
             if ($this->limit !== null && $this->generated >= $this->limit) {
+                $this->log->info("Limit reached -- downloading $this->limit {$this->resource->plural()}");
                 return;
             }
             yield $this->makeRequest((string) $slug);

--- a/src/Entity/SyncResource.php
+++ b/src/Entity/SyncResource.php
@@ -55,6 +55,10 @@ class SyncResource
         #[ORM\Column]
         public readonly int $pulled,
 
+        // when this record was checked, regardless of sync
+        #[ORM\Column]
+        public readonly int $checked,
+
         // last updated date in metadata
         #[ORM\Column]
         public readonly ?int $updated,

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -280,6 +280,15 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
 
     private function slugAndVersionExists(string $slug, string $version): bool
     {
+        // update checked timestamp
+        $this
+            ->connection()
+            ->update(
+                'sync',
+                ['checked' => time()],
+                ['slug' => $slug, 'version' => $version, ...$this->stdArgs()],
+            );
+
         return $this
             ->querySync()
             ->select('1')

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -62,6 +62,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             'origin' => $this->origin,
             'updated' => strtotime($metadata['last_updated'] ?? 'now'),
             'pulled' => time(),
+            'checked' => time(),
             'metadata' => $metadata,
         ]);
 
@@ -104,6 +105,7 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             'origin' => $this->origin,
             'updated' => strtotime($metadata['closed_date'] ?? 'now'),
             'pulled' => time(),
+            'checked' => time(),
             'metadata' => $metadata,
         ];
         $this->insertSync($row);
@@ -279,6 +281,12 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
 
     private function slugAndStatusExists(string $slug, string $status): bool
     {
+        $this->connection()->update(
+            'sync',
+            ['checked' => time()],
+            ['slug' => $slug, 'status' => $status, ...$this->stdArgs()],
+        );
+
         return $this
             ->querySync()
             ->select('1')

--- a/src/Services/Metadata/AbstractMetadataService.php
+++ b/src/Services/Metadata/AbstractMetadataService.php
@@ -128,6 +128,18 @@ abstract readonly class AbstractMetadataService implements MetadataServiceInterf
             ->fetchAllKeyValue();
     }
 
+    /** @return array<string,int> */
+    public function getCheckedAfter(int $timestamp): array
+    {
+        return $this
+            ->querySync()
+            ->select('slug', 'checked')
+            ->andWhere('checked > :timestamp')
+            ->setParameter('timestamp', $timestamp)
+            ->executeQuery()
+            ->fetchAllKeyValue();
+    }
+
     public function getDownloadUrl(string $slug, string $version): ?string
     {
         return $this

--- a/src/Services/Metadata/MetadataServiceInterface.php
+++ b/src/Services/Metadata/MetadataServiceInterface.php
@@ -29,6 +29,9 @@ interface MetadataServiceInterface
     /** @return array<string,int> */
     public function getPulledAfter(int $timestamp): array;
 
+    /** @return array<string,int> */
+    public function getCheckedAfter(int $timestamp): array;
+
     /** @return array<string|int, array{}> */
     public function getAllSlugs(): array;
 }

--- a/tests/Stubs/MetadataServiceStub.php
+++ b/tests/Stubs/MetadataServiceStub.php
@@ -49,6 +49,11 @@ class MetadataServiceStub implements MetadataServiceInterface
         return [];
     }
 
+    public function getCheckedAfter(int $timestamp): array
+    {
+        return [];
+    }
+
     public function getAllSlugs(): array
     {
         return [];


### PR DESCRIPTION
# Pull Request

## What changed?

* Adds a `checked` column to the `sync` table, which is unconditionally updated every time metadata was fetched, regardless of whether it was updated. 
* Adds a --skip-checked-after option to filter by checked timestamp.
* Adds a --limit option to stop after attempting to fetch N urls.  --limit=0 will just show pending counts.
* Options for filtering by timestamp have switched to absolute unix timestamps instead of seconds-ago.

## Why did it change?

Since `pulled` was only being updated when metadata actually changed, it was doing a lot of redundant upstream fetches.  We don't want this happening when we're live-updating production.

Admittedly, `--skip-checked-after=$(( $(date +%s) - 3600 ))` is not the  most user-friendly way to say "skip items checked within the last hour", but I'm not inclined to add strtotime() to the mix just yet.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

