### PR TITLE
hack: loop dee loop (run update-loop in a loop)

### DIFF
--- a/bin/update-loop-parent
+++ b/bin/update-loop-parent
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# For some reason, the update-loop job in kubernetes sometimes just quits silently.
+# Possibly k8s doesn't like self-exec loops: this loop exists to supervise that one so that the PID remains static.
+
+cd $(dirname $0)
+
+while true
+do
+  ./update-loop || true
+  echo "********** $(date) Update loop exited -- restarting in 60s **********" >&2
+  sleep 60 # in case update-loop crashes instantly
+done
+
+# let's hope we never get here
+echo "WTF: true is no longer true?" >&2
+exit 1


### PR DESCRIPTION
# Pull Request

## What changed?

Adds a new shell script to run update-loop in its own loop, in case update-loop for some reason exits successfully and thus signals the kubernetes job to exit.  It could also have to do with the loop using `exec $0` and perhaps that confuses a job?  Mysterious are the ways of k8s, so I wave this dead chicken to see if that fixes it. 

## Why did it change?

The aspiresync-job kept exiting with no error or message, for reasons unknown.  Hopefully this prevents that.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

