### PR TITLE
tweak: drop log level to INFO, make configurable

### DIFF
--- a/bin/update-sync
+++ b/bin/update-sync
@@ -7,6 +7,8 @@ TMPDIR=${TMPDIR:-/tmp}
 LOOKBACK_INTERVAL=${LOOKBACK_INTERVAL:--2 days}
 RECHECK_INTERVAL=${RECHECK_INTERVAL:--4 hours}
 
+verbosity=-vv
+
 function main () {
   plugins=$(mktemp $TMPDIR/plugins.list.XXXXXXXX)
   themes=$(mktemp $TMPDIR/themes.list.XXXXXXXX)
@@ -21,14 +23,14 @@ function main () {
   svn/bin/ls-updated-plugins $ymd | sort > $plugins
   svn/bin/ls-updated-themes $ymd | sort > $themes
 
-  bin/console sync:fetch:plugins -vvv --slugs-from=$plugins --skip-checked-after="$RECHECK_INTERVAL"
-  bin/console sync:fetch:themes -vvv --slugs-from=$themes --skip-checked-after="$RECHECK_INTERVAL"
+  bin/console sync:fetch:plugins $verbosity --slugs-from=$plugins --skip-checked-after="$RECHECK_INTERVAL"
+  bin/console sync:fetch:themes $verbosity --slugs-from=$themes --skip-checked-after="$RECHECK_INTERVAL"
 
   bin/popular-plugins 100 | jq -r '.slug' | sort > $plugins
   bin/popular-themes 100  | jq -r '.slug' | sort > $themes
 
-  bin/console sync:fetch:plugins -vvv --slugs-from=$plugins --skip-checked-after="$RECHECK_INTERVAL"
-  bin/console sync:fetch:themes -vvv --slugs-from=$themes --skip-checked-after="$RECHECK_INTERVAL"
+  bin/console sync:fetch:plugins $verbosity --slugs-from=$plugins --skip-checked-after="$RECHECK_INTERVAL"
+  bin/console sync:fetch:themes $verbosity --slugs-from=$themes --skip-checked-after="$RECHECK_INTERVAL"
 }
 
 main "$@"


### PR DESCRIPTION
# Pull Request

## What changed?

Logs aspiresync-job at INFO instead of DEBUG, since DEBUG never has useful output for this job.

## Why did it change?

Too much log spam.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

