### PR TITLE
quality-of-life tweaks for developers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
 
-COMPOSER = composer
-#COMPOSER = docker compose run -it --rm aspiresync composer
+EXEC := meta/bin/dcexec
+# EXEC :=
+
+COMPOSER := $(EXEC) composer
 
 build:
 	$(COMPOSER) install
+
+init: init-docker build migrate
+
+init-docker:
+	docker compose down --remove-orphans --volumes
+	docker compose up -d
+
+migrate:
+	$(EXEC) bin/console doctrine:migrations:migrate --no-interaction
 
 test:
 	$(COMPOSER) run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,11 @@ services:
       aspire-net:
         aliases:
           - 'db.sync.aspiredev.org'
+    healthcheck:
+      test: [ "CMD", "pg_isready" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
 networks:
   app-net: ~

--- a/meta/bin/dcexec
+++ b/meta/bin/dcexec
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. $(dirname $0)/prelude.bash
+
+if which docker >/dev/null 2>&1; then
+  exec docker compose exec $APP_SERVICE "$@"
+else
+  # no docker means we're probably already in docker
+  exec "$@"
+fi

--- a/meta/bin/prelude.bash
+++ b/meta/bin/prelude.bash
@@ -1,6 +1,8 @@
 # This file should be sourced, not run
 [[ -n $TRACE ]] && [[ $TRACE != 0 ]] && set -x
 
+APP_SERVICE=${APP_SERVICE:-webapp}
+
 set -o errexit
 
 cd $(dirname $0)/../..


### PR DESCRIPTION
# Pull Request

## What changed?

* Adds `make init` which should scrape and install everything.  Note there is no test init process because the test suite still uses the main db, which really ought to be fixed 😬
* Adds a healthcheck to the postgres service in docker-compose.yml
* adds `meta/bin/dcexec` which runs commands in a container if you're not in one already.  The makefile uses this for all targets where it matters.

## Why did it change?

Need to make onboarding easier

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

